### PR TITLE
chore: update plugin version to 0.2.1 and download link

### DIFF
--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",
@@ -12,5 +12,5 @@
 		"dev.shared.do_gamer.module.spaceball.Spaceball"
 	],
 	"update": "https://raw.githubusercontent.com/Darkbot-Plugins/SharedPlugin/main/src/main/resources/plugin.json",
-	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/download/v0.2.0/SharedPlugin.jar"
+	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/download/v0.2.1/SharedPlugin.jar"
 }


### PR DESCRIPTION
Update version number and corresponding download URL to match the new release

## Summary by Sourcery

Chores:
- Bump plugin.json version to 0.2.1 and align the download link with the new release artifact.