### PR TITLE
feat: add PET stuck fix and bump version to 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ We will seek to implement CI/CD in the repository so that developers have a good
 - Ore Seller: Sells ores at base, via PET trader gear, or using the HM7 trade drone when cargo is full. By @do-gamer
 - Solaris Ability: Activate Solaris (also Paladin) ability when there are a certain number of NPCs nearby. By @do-gamer
 - SpaceBall: Attack SpaceBall without fleeing away and collect cargo boxes around the gate. By @do-gamer
+- Fix PET stuck: Reloads the game when the PET window gets stuck. By @do-gamer
 
 ## Contributing
 

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",
@@ -13,5 +13,5 @@
 		"dev.shared.do_gamer.behaviour.FixPetStuck"
 	],
 	"update": "https://raw.githubusercontent.com/Darkbot-Plugins/SharedPlugin/main/src/main/resources/plugin.json",
-	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/download/v0.2.1/SharedPlugin.jar"
+	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/download/v0.3.0/SharedPlugin.jar"
 }


### PR DESCRIPTION
Add new feature to reload game when PET window gets stuck. Update plugin version and download URL accordingly.

## Summary by Sourcery

Document PET stuck auto-reload behavior and update plugin metadata for the 0.3.0 release.

New Features:
- Add a PET stuck recovery feature that reloads the game when the PET window becomes unresponsive.

Documentation:
- Document the PET stuck auto-reload feature in the README.