### PR TITLE
feat: add Close AD Offer feature and bump version to 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ We will seek to implement CI/CD in the repository so that developers have a good
 - SpaceBall: Attack SpaceBall without fleeing away and collect cargo boxes around the gate. By @do-gamer
 - Fix PET stuck: Reloads the game when the PET window gets stuck. By @do-gamer
 - Repair PET: Repairs your PET when its health drops below a certain threshold. By @do-gamer
+- Close AD Offer: Automatically closes AD Offer on the left side (temporary solution until the bot is fixed). By @do-gamer
 
 ## Contributing
 

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.4.2",
+	"version": "0.5.0",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",
@@ -15,5 +15,5 @@
 		"dev.shared.do_gamer.task.CloseAdOffer"
 	],
 	"update": "https://raw.githubusercontent.com/Darkbot-Plugins/SharedPlugin/main/src/main/resources/plugin.json",
-	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/download/v0.4.2/SharedPlugin.jar"
+	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/download/v0.5.0/SharedPlugin.jar"
 }


### PR DESCRIPTION
Add temporary solution to automatically close AD Offer on the left side. Update plugin version and download link accordingly.

## Summary by Sourcery

Document the new Close AD Offer feature and update plugin metadata for the 0.5.0 release.

New Features:
- Introduce a Close AD Offer action that automatically closes the AD offer panel on the left side.

Documentation:
- Add the Close AD Offer feature to the README feature list.