### PR TITLE
Ore Seller: Avoid selling ore between Galaxy Gate waves

### DIFF
--- a/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
+++ b/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
@@ -524,6 +524,7 @@ public class OreSeller extends TemporalModule implements Behavior, Configurable<
     private boolean prepareNonBaseSellingState(State nextState) {
         if (this.isGGMap()) {
             this.state = nextState;
+            this.movement.stop(false);
             return true; // No need for safety finder in GG maps
         }
         if (this.safetyFinder == null) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Avoid selling ore between Galaxy Gate waves by keeping the seller inactive whenever NPCs are present on GG maps.