### PR TITLE
chore: bump plugin version to 0.5.2

### DIFF
--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update the declared plugin version in plugin.json to 0.5.2.