### PR TITLE
Ore Seller: Abort if auto-refine or auto upgrade weapons reduced the cargo fill

### DIFF
--- a/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
+++ b/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
@@ -889,9 +889,7 @@ public class OreSeller extends TemporalModule implements Behavior, Configurable<
         }
 
         // Recalculate trigger state
-        double cargoPercent = this.getCargoPercent();
-        double threshold = this.normalizeTriggerThreshold();
-        boolean result = (cargoPercent >= threshold);
+        boolean result = (this.getCargoPercent() >= this.normalizeTriggerThreshold());
 
         this.cachedTriggerResult = result;
         triggerTimer.activate(TRIGGER_STATE_CACHE_DELAY_MS);


### PR DESCRIPTION
### Bug Fixes:
- Abort flight to safe when automatic refinement or automatic upgrade of weapons reduced cargo fill.
- Caching the result of the selling trigger check to give some time for other in-game actions.