### PR TITLE
Refactored ore sales in Galaxy Gate, and fixed the seller window that was stuck.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
+++ b/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
@@ -17,6 +17,7 @@ import eu.darkbot.api.config.ConfigSetting;
 import eu.darkbot.api.extensions.Behavior;
 import eu.darkbot.api.extensions.Configurable;
 import eu.darkbot.api.extensions.Feature;
+import eu.darkbot.api.game.entities.Portal;
 import eu.darkbot.api.game.entities.Station;
 import eu.darkbot.api.game.enums.PetGear;
 import eu.darkbot.api.game.items.ItemFlag;
@@ -346,6 +347,11 @@ public class OreSeller extends TemporalModule implements Behavior, Configurable<
 
         // Keep inactive while attacking
         if (this.attacker.hasTarget() && this.attacker.isAttacking()) {
+            return false;
+        }
+
+        // Keep inactive if jumping through portal
+        if (this.entities.getPortals().stream().anyMatch(Portal::isJumping)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary by Sourcery

Simplify and harden the ore selling behavior lifecycle, particularly around Galaxy Gate maps and trade completion, while improving safety checks.

Bug Fixes:
- Ensure the ore seller module stops cleanly when behavior prerequisites are not met or operations time out, preventing it from getting stuck.
- Prevent ore selling from running in Galaxy Gates when NPCs are within a nearby distance threshold instead of any NPC on the map.
- Avoid triggering ore selling while the ship is jumping through a portal.
- Require PET trader gear to be off cooldown before using it for ore selling.

Enhancements:
- Unify and simplify the module termination path by replacing multiple abort paths and the dedicated abortStart handler with a single finish method that always closes the trade window and resets state.
- Refine the NPC proximity check to use a configurable distance threshold from the hero instead of just presence.
- Make the ore seller finish immediately when the CLOSE_TRADE state is reached instead of managing a separate close-trade handler.