### PR TITLE
Ore Seller: fixed traveling to base and max percent.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
+++ b/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
@@ -16,7 +16,6 @@ import eu.darkbot.api.config.ConfigSetting;
 import eu.darkbot.api.extensions.Behavior;
 import eu.darkbot.api.extensions.Configurable;
 import eu.darkbot.api.extensions.Feature;
-import eu.darkbot.api.game.entities.Portal;
 import eu.darkbot.api.game.entities.Station;
 import eu.darkbot.api.game.enums.PetGear;
 import eu.darkbot.api.game.items.ItemFlag;
@@ -345,11 +344,6 @@ public class OreSeller extends TemporalModule implements Behavior, Configurable<
 
         // Keep inactive while attacking
         if (this.attacker.hasTarget() && this.attacker.isAttacking()) {
-            return false;
-        }
-
-        // Keep inactive if jumping through portal
-        if (this.entities.getPortals().stream().anyMatch(Portal::isJumping)) {
             return false;
         }
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust ore selling behavior for base travel detection and cargo trigger thresholds.

Bug Fixes:
- Fix detection of being on the desired base map when preparing and handling travel to base.
- Avoid prematurely finishing ore selling when a desired base map cannot be resolved.

Enhancements:
- Remove portal-jumping guard so ore selling can remain active while using portals.
- Allow configuring cargo trigger percentage above the previous hard maximum by only enforcing a minimum threshold.