### PR TITLE
Bump plugin version to 0.8.2

### DIFF
--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Bump plugin.json plugin version to 0.8.2 for release tagging.