### PR TITLE
Ore Seller: removed from setting Seprom and Osmium ore.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
+++ b/src/main/java/dev/shared/do_gamer/behaviour/OreSeller.java
@@ -925,12 +925,8 @@ public class OreSeller extends TemporalModule implements Behavior, Configurable<
                 return this.config.ores.duranium;
             case PROMERIUM:
                 return this.config.ores.promerium;
-            case SEPROM:
-                return this.config.ores.seprom;
             case PALLADIUM:
                 return this.shouldSellPalladium(mode);
-            case OSMIUM:
-                return this.config.ores.osmium;
             default:
                 return false;
         }

--- a/src/main/java/dev/shared/do_gamer/config/OreSellerConfig.java
+++ b/src/main/java/dev/shared/do_gamer/config/OreSellerConfig.java
@@ -110,13 +110,7 @@ public class OreSellerConfig {
         @Option("do_gamer.ore_seller.ores.promerium")
         public boolean promerium = true;
 
-        @Option("do_gamer.ore_seller.ores.seprom")
-        public boolean seprom = false;
-
         @Option("do_gamer.ore_seller.ores.palladium")
         public boolean palladium = false;
-
-        @Option("do_gamer.ore_seller.ores.osmium")
-        public boolean osmium = false;
     }
 }

--- a/src/main/resources/dev/shared/lang/strings_en.properties
+++ b/src/main/resources/dev/shared/lang/strings_en.properties
@@ -33,9 +33,7 @@ do_gamer.ore_seller.ores.terbium=Sell Terbium
 do_gamer.ore_seller.ores.prometid=Sell Prometid
 do_gamer.ore_seller.ores.duranium=Sell Duranium
 do_gamer.ore_seller.ores.promerium=Sell Promerium
-do_gamer.ore_seller.ores.seprom=Sell Seprom
 do_gamer.ore_seller.ores.palladium=Sell Palladium
-do_gamer.ore_seller.ores.osmium=Sell Osmium
 
 do_gamer.solaris_inc.config.npc=NPC settings
 do_gamer.solaris_inc.config.npc.max_distance=Max distance to NPCs


### PR DESCRIPTION
## Summary by Sourcery

Remove Seprom and Osmium from the ore seller configuration and selling logic.

Bug Fixes:
- Prevent Seprom and Osmium from being sellable via the ore seller feature.

Documentation:
- Remove Seprom and Osmium ore seller options from the English language strings.