### PR TITLE
Simple Galaxy Gate: Fixed Kamikaze bug when PET flies away to the corner.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
@@ -1,5 +1,6 @@
 package dev.shared.do_gamer.module.simple_galaxy_gate;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -291,7 +292,22 @@ public final class KamikazeHandler {
             }
         }
 
+        this.lockClosestTarget(validTargets);
         return false;
+    }
+
+    /**
+     * Lock the closest NPC to the hero
+     */
+    private void lockClosestTarget(List<Npc> validTargets) {
+        Npc closest = validTargets.stream()
+                .min(Comparator.comparingDouble(n -> n.distanceTo(this.hero)))
+                .orElse(null);
+
+        if (closest != null) {
+            this.lootModule.getAttacker().setTarget(closest);
+            this.lootModule.getAttacker().tryLockTarget();
+        }
     }
 
     /**

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.10.22",
+	"version": "0.10.23",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Select and lock the closest NPC to the hero to prevent the kamikaze logic from leaving the PET without a target and flying to a corner