### PR TITLE
Simple Galaxy Gate: Fixed the ship stuck bug at the LoW gate.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/LowGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/LowGate.java
@@ -34,6 +34,9 @@ public class LowGate extends GateHandler {
     private BossState bossState = BossState.NONE;
 
     public LowGate() {
+        this.npcMap.put("-=[ Century Falcon ]=-", new NpcParam(600.0, 50));
+        this.npcMap.put("-=[ Vagrant ]=-", new NpcParam(540.0, 100, NpcFlag.AGGRESSIVE_FOLLOW));
+
         this.defaultNpcParam = new NpcParam(540.0, NpcFlag.AGGRESSIVE_FOLLOW);
         this.jumpToNextMap = false;
         this.moveToCenter = false;
@@ -133,13 +136,6 @@ public class LowGate extends GateHandler {
     }
 
     /**
-     * Checks if the given NPC is a Vagrant.
-     */
-    private boolean isVagrant(Npc npc) {
-        return this.nameEquals(npc, "-=[ Vagrant ]=-");
-    }
-
-    /**
      * Handles the attack on relays.
      */
     private void handleRelayAttack(Relay targetRelay) {
@@ -196,11 +192,6 @@ public class LowGate extends GateHandler {
 
     @Override
     public KillDecision shouldKillNpc(Npc npc) {
-        // Do not kill Vagrant when boss has arrived
-        if (this.bossState == BossState.ARRIVED && this.isVagrant(npc)) {
-            return KillDecision.NO;
-        }
-
         // Skip Relays if NPCs present
         if (npc instanceof Relay && !this.module.lootModule.getNpcs().isEmpty()) {
             return KillDecision.NO;

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.10.23",
+	"version": "0.10.24",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Adjust NPC configuration and targeting rules in the LoW galaxy gate to prevent ships from getting stuck.

New Features:
- Define explicit NPC parameters for Century Falcon and Vagrant in the LoW gate configuration.

Bug Fixes:
- Remove special-case logic that prevented killing Vagrant after the boss arrived, avoiding situations where the ship could get stuck at the gate.