### PR TITLE
Simple Galaxy Gate: Updates and fixes.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
@@ -51,11 +51,11 @@ public final class CustomCollectorModule extends CollectorModule {
             this.findBox();
             Box box = this.currentBox;
             if (box != null && box.isValid()) {
-                this.tryCollectNearestBox();
+                this.collectBox();
                 return true;
             }
         }
-        return false;
+        return !this.hasNoBox();
     }
 
     @Override

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
@@ -6,9 +6,6 @@ import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.stream.Collectors;
 
-import com.github.manolo8.darkbot.Main;
-import com.github.manolo8.darkbot.core.objects.facades.SettingsProxy;
-
 import dev.shared.do_gamer.module.simple_galaxy_gate.config.GateNpcFlag;
 import dev.shared.do_gamer.module.simple_galaxy_gate.config.Maps;
 import dev.shared.do_gamer.module.simple_galaxy_gate.config.SimpleGalaxyGateConfig;
@@ -32,7 +29,6 @@ public final class KamikazeHandler {
     private final MovementAPI movement;
     private final PetAPI pet;
     private final GroupAPI group;
-    private final SettingsProxy settingsProxy;
     private final PetGearHelper petGearHelper;
 
     private SimpleGalaxyGateConfig config;
@@ -60,7 +56,6 @@ public final class KamikazeHandler {
         this.movement = api.requireAPI(MovementAPI.class);
         this.pet = api.requireAPI(PetAPI.class);
         this.group = api.requireAPI(GroupAPI.class);
-        this.settingsProxy = Main.INSTANCE.facadeManager.settings;
         this.petGearHelper = new PetGearHelper(api);
     }
 
@@ -163,9 +158,8 @@ public final class KamikazeHandler {
             if (!this.stuckTimer.isArmed()) {
                 // Arm the timer to detect if PET HP is stuck at 0 after respawn
                 this.stuckTimer.activate();
-            } else if (this.stuckTimer.isInactive()) {
-                // Timer expired, try to reactivate PET
-                this.settingsProxy.pressKeybind(SettingsProxy.KeyBind.ACTIVE_PET);
+            } else if (this.stuckTimer.isInactive() && this.petGearHelper.reset()) {
+                // If reset was successful, disarm the stuck timer
                 this.stuckTimer.disarm();
             }
         }

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
@@ -49,7 +49,7 @@ public final class SimpleGalaxyGate implements Module, Task,
 
     public final HeroAPI hero;
     public final MovementAPI movement;
-    private final PetAPI pet;
+    public final PetAPI pet;
     public final EntitiesAPI entities;
     public final CustomLootModule lootModule;
     public final CustomCollectorModule collectorModule;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
@@ -17,6 +17,7 @@ import dev.shared.do_gamer.module.simple_galaxy_gate.config.GateNpcFlag;
 import dev.shared.do_gamer.module.simple_galaxy_gate.config.Maps;
 import dev.shared.do_gamer.module.simple_galaxy_gate.config.SimpleGalaxyGateConfig;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.GateHandler;
+import dev.shared.do_gamer.utils.PetGearHelper;
 import dev.shared.do_gamer.utils.ServerTimeHelper;
 import eu.darkbot.api.PluginAPI;
 import eu.darkbot.api.config.ConfigSetting;
@@ -81,6 +82,7 @@ public final class SimpleGalaxyGate implements Module, Task,
     private int completedGates = 0;
 
     private final GateBuilder gateBuilder;
+    public final PetGearHelper petGearHelper;
 
     private SimpleGalaxyGateConfig config;
     private String statusDetails = null;
@@ -105,6 +107,7 @@ public final class SimpleGalaxyGate implements Module, Task,
         this.botBrowserApi = this.configApi.requireConfig("bot_settings.api_config.browser_api");
         this.lootModule.setCollector(this.collectorModule); // Link collector module
         this.gateBuilder = new GateBuilder(this, api);
+        this.petGearHelper = new PetGearHelper(api);
     }
 
     @Override

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
@@ -36,7 +36,6 @@ import eu.darkbot.api.managers.ExtensionsAPI;
 import eu.darkbot.api.managers.GameScreenAPI;
 import eu.darkbot.api.managers.HeroAPI;
 import eu.darkbot.api.managers.MovementAPI;
-import eu.darkbot.api.managers.PetAPI;
 import eu.darkbot.api.managers.RepairAPI;
 import eu.darkbot.api.managers.StarSystemAPI;
 import eu.darkbot.shared.utils.MapTraveler;
@@ -50,7 +49,6 @@ public final class SimpleGalaxyGate implements Module, Task,
 
     public final HeroAPI hero;
     public final MovementAPI movement;
-    public final PetAPI pet;
     public final EntitiesAPI entities;
     public final CustomLootModule lootModule;
     public final CustomCollectorModule collectorModule;
@@ -90,7 +88,6 @@ public final class SimpleGalaxyGate implements Module, Task,
     public SimpleGalaxyGate(PluginAPI api) {
         this.hero = api.requireAPI(HeroAPI.class);
         this.movement = api.requireAPI(MovementAPI.class);
-        this.pet = api.requireAPI(PetAPI.class);
         this.entities = api.requireAPI(EntitiesAPI.class);
         this.lootModule = new CustomLootModule(api);
         this.collectorModule = new CustomCollectorModule(api);
@@ -373,7 +370,7 @@ public final class SimpleGalaxyGate implements Module, Task,
         if (this.gateBuilder.tick()) {
             StateStore.request(StateStore.State.BUILDING);
             this.moveToRefinery(); // Stay near refinery while building
-            this.pet.setEnabled(false); // Disable pet while building
+            this.petGearHelper.disable(); // Disable pet while building
             return;
         }
 

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -113,7 +113,8 @@ public class DseGate extends GateHandler {
         // Check if we're in Command Hall to handle box populate and gate reset logic
         if (this.module.starSystem.getCurrentMap().getId() == COMMAND_HALL_MAP_ID) {
             this.showBoxCount = true; // Show box count in Command Hall
-            this.module.pet.setEnabled(false); // Disable pet in Command Hall
+            // Try deactivate PET to prevent became bugged
+            this.module.petGearHelper.disable();
 
             // Activate small delay for preload Command Hall
             if (!this.delay.isArmed()) {

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -167,9 +167,8 @@ public class DseGate extends GateHandler {
             }
 
             // Collect boxes if available, otherwise wait for jump or timeout
-            if (!this.module.collectorModule.hasNoBox()) {
+            if (this.module.collectorModule.collectIfAvailable()) {
                 StateStore.request(StateStore.State.COLLECTING);
-                this.module.collectorModule.collectIfAvailable();
                 return true;
             }
 

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -14,6 +14,7 @@ public class DseGate extends GateHandler {
     private static final int COMMAND_HALL_MAP_ID = 473; // Map ID for Command Center
     private static final double REPAIR_RADIUS = 3_000.0;
     private Timer jumpTimer = Timer.get(20_000L);
+    private Timer delay = Timer.get(3_000L);
 
     public DseGate() {
         this.npcMap.put("-={ Gygerim Overlord }=-", new NpcParam(590.0, -95));
@@ -26,6 +27,7 @@ public class DseGate extends GateHandler {
         this.defaultNpcParam = new NpcParam(580.0);
         this.repairRadius = REPAIR_RADIUS;
         this.approachToCenter = false;
+        this.jumpToNextMap = false;
         this.useGuardableNpcAsSearchLocation = true;
         this.showCompletedGates = false;
     }
@@ -44,6 +46,7 @@ public class DseGate extends GateHandler {
     @Override
     public void reset() {
         this.jumpTimer.disarm();
+        this.delay.disarm();
         this.resetCachedGuardableNpc();
     }
 
@@ -110,11 +113,18 @@ public class DseGate extends GateHandler {
         // Check if we're in Command Hall to handle box populate and gate reset logic
         if (this.module.starSystem.getCurrentMap().getId() == COMMAND_HALL_MAP_ID) {
             this.showBoxCount = true; // Show box count in Command Hall
+            this.module.pet.setEnabled(false); // Disable pet in Command Hall
+
+            // Activate small delay for preload Command Hall
+            if (!this.delay.isArmed()) {
+                this.delay.activate();
+            }
 
             // Wait manual selection of ship or reset gate
             if (this.getVisibleGui(SHIP_HANGAR_GUI).isPresent()
                     || this.getVisibleGui(SHIP_WARP_GUI).isPresent()
-                    || (this.jumpTimer.isArmed() && this.jumpTimer.isInactive())) {
+                    || (this.jumpTimer.isArmed() && this.jumpTimer.isInactive())
+                    || this.delay.isActive()) {
                 StateStore.request(StateStore.State.WAITING_IN_GATE);
                 return true;
             }
@@ -123,7 +133,16 @@ public class DseGate extends GateHandler {
             if (StateStore.current() == StateStore.State.JUMPING && !this.jumpTimer.isArmed()) {
                 this.jumpTimer.activate();
             }
-            return false;
+
+            // Collect boxes if available, otherwise wait for jump or timeout
+            if (!this.module.collectorModule.hasNoBox()) {
+                StateStore.request(StateStore.State.COLLECTING);
+                this.module.collectorModule.collectIfAvailable();
+                return true;
+            }
+
+            this.module.jumpToNextMap();
+            return true;
         }
 
         this.showBoxCount = false; // Hide box count when in gate

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -4,6 +4,7 @@ import dev.shared.do_gamer.module.simple_galaxy_gate.StateStore;
 import eu.darkbot.api.config.types.NpcFlag;
 import eu.darkbot.api.game.entities.Npc;
 import eu.darkbot.api.game.other.GameMap;
+import eu.darkbot.api.game.other.Lockable;
 import eu.darkbot.util.Timer;
 
 public class DseGate extends GateHandler {
@@ -109,6 +110,18 @@ public class DseGate extends GateHandler {
     private boolean hasNearbyMissileStorm(Npc npc) {
         return !this.npcHasMissileStormName(npc) && this.module.lootModule.getNpcs().stream()
                 .anyMatch(n -> this.npcHasMissileStormName(n) && n.distanceTo(this.getNpcSearchLocation()) < 2_000.0);
+    }
+
+    @Override
+    public double getTargetRadius(Lockable target) {
+        double radius = super.getTargetRadius(target);
+
+        Npc guardableNpc = this.getGuardableNpc();
+        if (guardableNpc != null && !this.isGuardableNpc((Npc) target)
+                && target.distanceTo(guardableNpc) >= this.getFarTargetDistance()) {
+            return radius * 0.5; // Reduce radius for target far from the guardable NPC
+        }
+        return radius;
     }
 
     @Override

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -115,11 +115,12 @@ public class DseGate extends GateHandler {
     @Override
     public double getTargetRadius(Lockable target) {
         double radius = super.getTargetRadius(target);
-
-        Npc guardableNpc = this.getGuardableNpc();
-        if (guardableNpc != null && !this.isGuardableNpc((Npc) target)
-                && target.distanceTo(guardableNpc) >= this.getFarTargetDistance()) {
-            return radius * 0.5; // Reduce radius for target far from the guardable NPC
+        if (target != null && this.getGuardableNpc() != null) {
+            Npc npc = (Npc) target;
+            if (!this.isGuardableNpc(npc) && !npc.isAttacking(this.module.hero)) {
+                // Reduce radius for target not attacking hero when have guardable NPC
+                return radius * 0.75;
+            }
         }
         return radius;
     }

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -83,7 +83,24 @@ public class DseGate extends GateHandler {
         if (this.isGuardableNpc(npc)) {
             return KillDecision.NO;
         }
+
+        // If a guardable NPC is under attack by another NPC, don't kill this NPC
+        if (this.isGuardableNpcAttackedByOtherNpc(npc)) {
+            return KillDecision.NO;
+        }
+
         return super.shouldKillNpc(npc);
+    }
+
+    /**
+     * Checks whether a guardable NPC is currently under attack by another NPC.
+     */
+    private boolean isGuardableNpcAttackedByOtherNpc(Npc npc) {
+        Npc guardableNpc = this.getGuardableNpc();
+        return guardableNpc != null
+                && !npc.isAttacking(guardableNpc)
+                && this.module.lootModule.getNpcs().stream()
+                        .anyMatch(n -> !this.isGuardableNpc(n) && n.isAttacking(guardableNpc));
     }
 
     /**

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/LowGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/LowGate.java
@@ -34,7 +34,7 @@ public class LowGate extends GateHandler {
     private BossState bossState = BossState.NONE;
 
     public LowGate() {
-        this.npcMap.put("-=[ Century Falcon ]=-", new NpcParam(600.0, 50));
+        this.npcMap.put("-=[ Century Falcon ]=-", new NpcParam(580.0, 50, NpcFlag.NO_CIRCLE));
         this.npcMap.put("-=[ Vagrant ]=-", new NpcParam(540.0, 100, NpcFlag.AGGRESSIVE_FOLLOW));
 
         this.defaultNpcParam = new NpcParam(540.0, NpcFlag.AGGRESSIVE_FOLLOW);

--- a/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
+++ b/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
@@ -133,12 +133,12 @@ public class PetGearHelper {
      * Try to reset the PET if it's bugged
      */
     public boolean reset() {
-        if (this.isEnabled() && this.resetTimer.isInactive()) {
-            // Attempt to reset the PET by pressing the "active" keybind
-            this.settingsProxy.pressKeybind(SettingsProxy.KeyBind.ACTIVE_PET);
+        if (this.isEnabled() && this.resetTimer.isInactive()
+                && this.settingsProxy.pressKeybind(SettingsProxy.KeyBind.ACTIVE_PET)) {
             this.resetTimer.activate();
             return true;
         }
+
         return false;
     }
 

--- a/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
+++ b/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
@@ -2,12 +2,16 @@ package dev.shared.do_gamer.utils;
 
 import java.util.List;
 
+import com.github.manolo8.darkbot.Main;
+import com.github.manolo8.darkbot.core.objects.facades.SettingsProxy;
+
 import eu.darkbot.api.PluginAPI;
 import eu.darkbot.api.game.enums.PetGear;
 import eu.darkbot.api.game.other.Health;
 import eu.darkbot.api.managers.ConfigAPI;
 import eu.darkbot.api.managers.PetAPI;
 import eu.darkbot.api.utils.ItemNotEquippedException;
+import eu.darkbot.util.Timer;
 
 /**
  * Helper for safely managing PET gear usage.
@@ -16,6 +20,8 @@ public class PetGearHelper {
 
     private final PetAPI pet;
     private final ConfigAPI configApi;
+    private final SettingsProxy settingsProxy;
+    private final Timer resetTimer = Timer.get(2_000L);
 
     // List of gears that restrict the use of other gears when active
     private static final List<PetGear> RESTRICTED_GEARS = List.of(
@@ -31,6 +37,7 @@ public class PetGearHelper {
     public PetGearHelper(PluginAPI api) {
         this.pet = api.requireAPI(PetAPI.class);
         this.configApi = api.requireAPI(ConfigAPI.class);
+        this.settingsProxy = Main.INSTANCE.facadeManager.settings;
     }
 
     /**
@@ -120,5 +127,27 @@ public class PetGearHelper {
      */
     public Health getHealth() {
         return this.pet.getHealth();
+    }
+
+    /**
+     * Try to reset the PET if it's bugged
+     */
+    public boolean reset() {
+        if (this.isEnabled() && this.resetTimer.isInactive()) {
+            // Attempt to reset the PET by pressing the "active" keybind
+            this.settingsProxy.pressKeybind(SettingsProxy.KeyBind.ACTIVE_PET);
+            this.resetTimer.activate();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Disables the PET and attempts to reset it to prevent bugs.
+     */
+    public void disable() {
+        if (!this.reset()) {
+            this.setEnabled(false);
+        }
     }
 }

--- a/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
+++ b/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
@@ -21,7 +21,7 @@ public class PetGearHelper {
     private final PetAPI pet;
     private final ConfigAPI configApi;
     private final SettingsProxy settingsProxy;
-    private final Timer resetTimer = Timer.get(2_000L);
+    private final Timer resetTimer = Timer.get(1_000L);
 
     // List of gears that restrict the use of other gears when active
     private static final List<PetGear> RESTRICTED_GEARS = List.of(
@@ -130,7 +130,7 @@ public class PetGearHelper {
     }
 
     /**
-     * Try to reset the PET if it's bugged
+     * Try to reset the PET if it's bugged by pressing the active PET keybind.
      */
     public boolean reset() {
         if (this.isEnabled() && this.resetTimer.isInactive()

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.10.25",
+	"version": "0.10.26",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Improve Simple Galaxy Gate behavior around PET handling, gate transitions, and NPC targeting logic.

New Features:
- DSE: Adjust NPC targeting radius when a guardable NPC is present to deprioritize non-threatening targets.

Bug Fixes:
- DSE: Avoid attacking NPCs that are engaging a guardable NPC to prevent unintended interference.
- Prevent PET from getting stuck or bugged by adding a reset/disable helper used across gate and kamikaze logic.
- DSE: Ensure proper waiting and box collection behavior in the Command Hall before jumping to the next map.
- LoW: Added no circle extra flag and reduced radius for Century Falcon.

Enhancements:
- DSE: Refine Command Hall handling by deactivating PET, adding a short preload delay, and automatically jumping to the next map when appropriate.
- Centralize PET keybind-based reset logic in PetGearHelper and reuse it in KamikazeHandler and gate handling.