### PR TITLE
Autobuy: fixed Log Disks count.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/task/autobuy/Autobuy.java
+++ b/src/main/java/dev/shared/do_gamer/task/autobuy/Autobuy.java
@@ -176,7 +176,6 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
             int count = this.extractLogFileCount(html);
             this.resource.put(AutobuyConfig.SpecialConfig.LOG_FILE, count);
             this.state = State.FETCH_BOOSTERS;
-            System.out.println(String.format("Autobuy: Current log file count: %d", count));
         } catch (IOException e) {
             System.out.println(String.format("Autobuy: Failed to fetch log file count: %s", e.getMessage()));
             this.handleError();

--- a/src/main/java/dev/shared/do_gamer/task/autobuy/Autobuy.java
+++ b/src/main/java/dev/shared/do_gamer/task/autobuy/Autobuy.java
@@ -174,6 +174,11 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
                     .setRawParam("imgUrl", "")
                     .getContent();
             int count = this.extractLogFileCount(html);
+            if (count < 0) {
+                System.out.println("Autobuy: Failed to parse log file count from response, skipping cycle");
+                this.handleError();
+                return;
+            }
             this.resource.put(AutobuyConfig.SpecialConfig.LOG_FILE, count);
             this.state = State.FETCH_BOOSTERS;
         } catch (IOException e) {
@@ -403,26 +408,27 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
     }
 
     /**
-     * Extracts the log file count from HTML code.
+     * Returns the log file count parsed from the span,
+     * or -1 if the markup is absent or malformed.
      */
     private int extractLogFileCount(String html) {
         if (html == null) {
-            return 0;
+            return -1;
         }
         String marker = "<span id=\\\"logFileUpdated\\\">";
         int start = html.indexOf(marker);
         if (start < 0) {
-            return 0;
+            return -1;
         }
         int valueStart = start + marker.length();
         int end = html.indexOf("<\\/span>", valueStart);
         if (end < 0) {
-            return 0;
+            return -1;
         }
         try {
             return Integer.parseInt(html.substring(valueStart, end).trim());
         } catch (NumberFormatException e) {
-            return 0;
+            return -1;
         }
     }
 

--- a/src/main/java/dev/shared/do_gamer/task/autobuy/Autobuy.java
+++ b/src/main/java/dev/shared/do_gamer/task/autobuy/Autobuy.java
@@ -28,6 +28,7 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
         IDLE,
         REQUEST_INVENTORY,
         UPDATE_INVENTORY,
+        FETCH_LOG_FILE,
         FETCH_BOOSTERS,
         FETCH_SPECIALS,
         PREPARE_QUEUE,
@@ -90,6 +91,9 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
             case UPDATE_INVENTORY:
                 this.tickUpdateInventory();
                 break;
+            case FETCH_LOG_FILE:
+                this.tickFetchLogFile();
+                break;
             case FETCH_BOOSTERS:
                 this.tickFetchBoosters();
                 break;
@@ -134,9 +138,13 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
 
     /**
      * Reads current hangar quantities for tracked special items.
+     * LOG_FILE is skipped here; its count is fetched separately in FETCH_LOG_FILE.
      */
     private void tickUpdateInventory() {
         for (String key : this.resource.keySet()) {
+            if (AutobuyConfig.SpecialConfig.LOG_FILE.equals(key)) {
+                continue;
+            }
             int index = this.backpageManager.legacyHangarManager.getLootIds().indexOf(key);
             if (index != -1) {
                 int quantity = this.backpageManager.legacyHangarManager.getItems().stream()
@@ -147,7 +155,32 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
                 this.resource.put(key, quantity);
             }
         }
-        this.state = State.FETCH_BOOSTERS;
+        this.state = State.FETCH_LOG_FILE;
+    }
+
+    /**
+     * Fetches the log file count from the pilot profile skill tree page.
+     * Skipped if log file purchasing is not configured.
+     */
+    private void tickFetchLogFile() {
+        if (this.config.special.logFile.amount == 0) {
+            this.state = State.FETCH_BOOSTERS;
+            return;
+        }
+        try {
+            String html = this.backpageManager.postHttp("ajax/pilotprofil.php")
+                    .setRawParam("command", "getInternalProfilPage")
+                    .setRawParam("type", "showSkilltree")
+                    .setRawParam("imgUrl", "")
+                    .getContent();
+            int count = this.extractLogFileCount(html);
+            this.resource.put(AutobuyConfig.SpecialConfig.LOG_FILE, count);
+            this.state = State.FETCH_BOOSTERS;
+            System.out.println(String.format("Autobuy: Current log file count: %d", count));
+        } catch (IOException e) {
+            System.out.println(String.format("Autobuy: Failed to fetch log file count: %s", e.getMessage()));
+            this.handleError();
+        }
     }
 
     /**
@@ -368,6 +401,30 @@ public class Autobuy implements Task, Configurable<AutobuyConfig> {
             return null;
         }
         return itemDataElement.getAsJsonObject();
+    }
+
+    /**
+     * Extracts the log file count from HTML code.
+     */
+    private int extractLogFileCount(String html) {
+        if (html == null) {
+            return 0;
+        }
+        String marker = "<span id=\\\"logFileUpdated\\\">";
+        int start = html.indexOf(marker);
+        if (start < 0) {
+            return 0;
+        }
+        int valueStart = start + marker.length();
+        int end = html.indexOf("<\\/span>", valueStart);
+        if (end < 0) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(html.substring(valueStart, end).trim());
+        } catch (NumberFormatException e) {
+            return 0;
+        }
     }
 
     /**

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Adjust autobuy workflow to obtain log file counts from the pilot profile skill tree page instead of the hangar inventory.

New Features:
- Introduce a dedicated FETCH_LOG_FILE state in the autobuy state machine to retrieve log file quantities from the pilot profile.

Bug Fixes:
- Correct log disk (log file) quantity tracking by parsing the value from the skill tree HTML rather than the hangar inventory listing.

Enhancements:
- Centralize log file count extraction into a helper that parses the relevant span from the pilot profile HTML and updates the resource map.