### PR TITLE
Simple Galaxy Gate: Added "Finish Off" extra flag and logic for finishing low-HP NPCs.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomLootModule.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomLootModule.java
@@ -7,6 +7,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
+import dev.shared.do_gamer.module.simple_galaxy_gate.config.GateNpcFlag;
 import dev.shared.do_gamer.module.simple_galaxy_gate.config.Maps;
 import dev.shared.do_gamer.module.simple_galaxy_gate.config.SimpleGalaxyGateConfig;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.GateHandler;
@@ -25,6 +26,7 @@ import eu.darkbot.api.game.other.Lockable;
 import eu.darkbot.api.managers.ConfigAPI;
 import eu.darkbot.api.managers.EntitiesAPI;
 import eu.darkbot.shared.modules.LootModule;
+import eu.darkbot.util.Timer;
 
 public final class CustomLootModule extends LootModule {
 
@@ -39,6 +41,7 @@ public final class CustomLootModule extends LootModule {
     private GateHandler gateHandler;
     private boolean repair = false;
     private boolean approachingCenter = false;
+    private final Timer finishOffTimer = Timer.get(2_000L);
 
     private final KamikazeHandler kamikazeHandler;
 
@@ -174,7 +177,12 @@ public final class CustomLootModule extends LootModule {
         if (this.repair) {
             return; // Skip while repairing
         }
-        Npc target = (Npc) this.attack.getTargetAs(Npc.class);
+        Npc target = this.attack.getTargetAs(Npc.class);
+        // If finishing off, switch to run mode and skip other logic
+        if (this.isFinishingOff(target)) {
+            this.hero.setRunMode();
+            return;
+        }
         if (target != null && target.isValid()) {
             if (this.hero.distanceTo(target) > this.gateHandler.getFarTargetDistance()) {
                 this.hero.setRoamMode(); // If target is far, switch to roam mode
@@ -184,6 +192,20 @@ public final class CustomLootModule extends LootModule {
         } else {
             this.hero.setRoamMode();
         }
+    }
+
+    /**
+     * Determines if the target NPC should be finished off using Run config.
+     * And keep active for 2 seconds after to collect rewards safely.
+     */
+    private boolean isFinishingOff(Npc target) {
+        if (target != null && target.isValid()
+                && target.getInfo().hasExtraFlag(GateNpcFlag.FINISH_OFF)
+                && target.getHealth().hpPercent() < 0.25) {
+            this.finishOffTimer.activate();
+            return true;
+        }
+        return this.finishOffTimer.isActive();
     }
 
     /**

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/GateNpcFlag.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/GateNpcFlag.java
@@ -4,7 +4,8 @@ import com.github.manolo8.darkbot.config.NpcExtraFlag;
 
 public enum GateNpcFlag implements NpcExtraFlag {
     KAMIKAZE("K", "Kamikaze", "Use Kamikaze for this NPC"),
-    STICK_TO_TARGET("ST", "Stick to Target", "Stick to current target, don't switch away");
+    STICK_TO_TARGET("ST", "Stick to Target", "Stick to current target, don't switch away"),
+    FINISH_OFF("F", "Finish Off", "Switch to Run config below 25% HP until destroyed; wait 2s after for rewards");
 
     private final String shortName;
     private final String name;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/SimpleGalaxyGateConfig.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/SimpleGalaxyGateConfig.java
@@ -202,11 +202,11 @@ public final class SimpleGalaxyGateConfig {
              * Blacklight boosters.
              */
             private static final Map<String, CategoryData> categories = Map.of(
-                    EternalBlacklightGateAPI.Category.DAMAGE_LASER.name(), new CategoryData("Laser Damage", 0),
-                    EternalBlacklightGateAPI.Category.DAMAGE.name(), new CategoryData("Damage", 0),
-                    EternalBlacklightGateAPI.Category.HITCHANCE_LASER.name(), new CategoryData("Laser Hitchance", 0),
+                    EternalBlacklightGateAPI.Category.DAMAGE_LASER.name(), new CategoryData("Laser Damage", 1),
+                    EternalBlacklightGateAPI.Category.DAMAGE.name(), new CategoryData("Damage", 1),
+                    EternalBlacklightGateAPI.Category.HITCHANCE_LASER.name(), new CategoryData("Laser Hitchance", 1),
                     EternalBlacklightGateAPI.Category.HITPOINTS.name(), new CategoryData("Hitpoints", 1),
-                    EternalBlacklightGateAPI.Category.ABILITY_COOLDOWN_TIME.name(), new CategoryData("Cool Down", 1),
+                    EternalBlacklightGateAPI.Category.ABILITY_COOLDOWN_TIME.name(), new CategoryData("Cool Down", 2),
                     EternalBlacklightGateAPI.Category.SHIELD.name(), new CategoryData("Shield", 2),
                     EternalBlacklightGateAPI.Category.SPEED.name(), new CategoryData("Speed", 2),
                     EternalBlacklightGateAPI.Category.DAMAGE_ROCKETS.name(), new CategoryData("Rockets Damage", 2));

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/SimpleGalaxyGateConfig.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/SimpleGalaxyGateConfig.java
@@ -57,7 +57,8 @@ public final class SimpleGalaxyGateConfig {
             html.append(LINE_BREAK);
             html.append(buildList("NPC extra flags:",
                     "Kamikaze: allows Kamikaze for this NPC when the feature is enabled.",
-                    "Stick to Target: to stick to the current target, don't switch away."));
+                    "Stick to Target: to stick to the current target, don't switch away.",
+                    "Finish Off: Switch to <b>Run config</b> below 25% HP until destroyed."));
             html.append(LINE_BREAK);
             html.append(buildList("Gate-specific notes:",
                     "DSE gate requires <b>manual</b> action to select ship and reset waves."));

--- a/src/main/resources/dev/shared/lang/strings_en.properties
+++ b/src/main/resources/dev/shared/lang/strings_en.properties
@@ -132,6 +132,7 @@ do_gamer.simple_galaxy_gate.any_gate.move_to_center.desc=Move to the center of t
 do_gamer.simple_galaxy_gate.eternal_blacklight=Eternal Blacklight Gate Settings
 do_gamer.simple_galaxy_gate.eternal_blacklight.suicide_wave=Suicide on X wave
 do_gamer.simple_galaxy_gate.eternal_blacklight.try_split_uber_kristallon=Try splitting Uber Kristallons
+do_gamer.simple_galaxy_gate.eternal_blacklight.try_split_uber_kristallon.desc=Try to spread Uber Kristallons to different corners of the map.
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters=Boosters
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.desc=Selects boosters by lowest configured priority, then by highest booster effectiveness percentage.
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.priority=Priority

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.11.9",
+	"version": "0.11.10",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Add a configurable "Finish Off" behavior for low-HP NPCs in Simple Galaxy Gate, using run configuration to safely destroy flagged targets and collect rewards.

New Features:
- Introduce a FINISH_OFF NPC extra flag to control finishing behavior on low-HP NPCs.
- Add logic to switch the hero to run mode when attacking low-HP NPCs flagged with FINISH_OFF and keep it active briefly after destruction.

Enhancements:
- Update Simple Galaxy Gate configuration help text to document the new FINISH_OFF NPC flag and its behavior.