### PR TITLE
Simple Galaxy Gate - DSE: Don't overwrite the "stuck to target" logic with a custom one.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -1,5 +1,7 @@
 package dev.shared.do_gamer.module.simple_galaxy_gate.gate;
 
+import java.util.Objects;
+
 import dev.shared.do_gamer.module.simple_galaxy_gate.StateStore;
 import eu.darkbot.api.config.types.NpcFlag;
 import eu.darkbot.api.game.entities.Npc;
@@ -96,12 +98,22 @@ public final class DseGate extends GateHandler {
     }
 
     /**
+     * Checks if we should stick to the current target
+     */
+    private boolean shouldStickToCurrentTarget(Npc npc) {
+        Npc currentTarget = this.module.lootModule.getAttacker().getTargetAs(Npc.class);
+        return Objects.equals(npc, currentTarget) || this.isStickToTarget(currentTarget);
+    }
+
+    /**
      * Checks whether a guardable NPC is currently under attack by another NPC.
      */
     private boolean isGuardableNpcAttackedByOtherNpc(Npc npc) {
         Npc guardableNpc = this.getGuardableNpc();
-        return guardableNpc != null
-                && !npc.isAttacking(guardableNpc)
+        if (guardableNpc == null || this.shouldStickToCurrentTarget(npc)) {
+            return false; // No guardable NPC or sticking to current target, ignore this check
+        }
+        return !npc.isAttacking(guardableNpc)
                 && this.module.lootModule.getNpcs().stream()
                         .anyMatch(n -> !this.isGuardableNpc(n) && n.isAttacking(guardableNpc));
     }
@@ -110,7 +122,10 @@ public final class DseGate extends GateHandler {
      * Checks if there is a nearby Missile-Storm NPC.
      */
     private boolean hasNearbyMissileStorm(Npc npc) {
-        return !this.npcHasMissileStormName(npc) && this.module.lootModule.getNpcs().stream()
+        if (!this.npcHasMissileStormName(npc) || this.shouldStickToCurrentTarget(npc)) {
+            return false; // NPC is not Missile-Storm or sticking to current target, ignore this check
+        }
+        return this.module.lootModule.getNpcs().stream()
                 .anyMatch(n -> this.npcHasMissileStormName(n) && n.distanceTo(this.getNpcSearchLocation()) < 2_000.0);
     }
 

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -121,7 +121,7 @@ public final class DseGate extends GateHandler {
      */
     private boolean hasNearbyMissileStorm(Npc npc) {
         if (this.npcHasMissileStormName(npc) || this.shouldStickToCurrentTarget()) {
-            return false; // NPC is not Missile-Storm or sticking to current target, ignore this check
+            return false; // NPC is Missile-Storm or sticking to current target, ignore this check
         }
         return this.module.lootModule.getNpcs().stream()
                 .anyMatch(n -> this.npcHasMissileStormName(n) && n.distanceTo(this.getNpcSearchLocation()) < 2_000.0);

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -1,7 +1,5 @@
 package dev.shared.do_gamer.module.simple_galaxy_gate.gate;
 
-import java.util.Objects;
-
 import dev.shared.do_gamer.module.simple_galaxy_gate.StateStore;
 import eu.darkbot.api.config.types.NpcFlag;
 import eu.darkbot.api.game.entities.Npc;
@@ -100,9 +98,9 @@ public final class DseGate extends GateHandler {
     /**
      * Checks if we should stick to the current target
      */
-    private boolean shouldStickToCurrentTarget(Npc npc) {
+    private boolean shouldStickToCurrentTarget() {
         Npc currentTarget = this.module.lootModule.getAttacker().getTargetAs(Npc.class);
-        return Objects.equals(npc, currentTarget) || this.isStickToTarget(currentTarget);
+        return this.isStickToTarget(currentTarget);
     }
 
     /**
@@ -110,7 +108,7 @@ public final class DseGate extends GateHandler {
      */
     private boolean isGuardableNpcAttackedByOtherNpc(Npc npc) {
         Npc guardableNpc = this.getGuardableNpc();
-        if (guardableNpc == null || this.shouldStickToCurrentTarget(npc)) {
+        if (guardableNpc == null || this.shouldStickToCurrentTarget()) {
             return false; // No guardable NPC or sticking to current target, ignore this check
         }
         return !npc.isAttacking(guardableNpc)
@@ -122,7 +120,7 @@ public final class DseGate extends GateHandler {
      * Checks if there is a nearby Missile-Storm NPC.
      */
     private boolean hasNearbyMissileStorm(Npc npc) {
-        if (!this.npcHasMissileStormName(npc) || this.shouldStickToCurrentTarget(npc)) {
+        if (!this.npcHasMissileStormName(npc) || this.shouldStickToCurrentTarget()) {
             return false; // NPC is not Missile-Storm or sticking to current target, ignore this check
         }
         return this.module.lootModule.getNpcs().stream()

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -120,7 +120,7 @@ public final class DseGate extends GateHandler {
      * Checks if there is a nearby Missile-Storm NPC.
      */
     private boolean hasNearbyMissileStorm(Npc npc) {
-        if (!this.npcHasMissileStormName(npc) || this.shouldStickToCurrentTarget()) {
+        if (this.npcHasMissileStormName(npc) || this.shouldStickToCurrentTarget()) {
             return false; // NPC is not Missile-Storm or sticking to current target, ignore this check
         }
         return this.module.lootModule.getNpcs().stream()

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.11.12",
+	"version": "0.11.13",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Preserve existing target-sticking behavior while tightening special-case checks around guardable and Missile-Storm NPCs.

Bug Fixes:
- Avoid overriding the existing 'stick to target' logic when evaluating guardable NPC attacks and nearby Missile-Storm NPCs.

Enhancements:
- Introduce a helper to determine when to keep the current NPC target and use it to short-circuit certain defensive checks.