### PR TITLE
Utils: Increase reset timer duration in PetGearHelper to improve gear management stability.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
+++ b/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
@@ -21,7 +21,7 @@ public class PetGearHelper {
     private final PetAPI pet;
     private final ConfigAPI configApi;
     private final SettingsProxy settingsProxy;
-    private final Timer resetTimer = Timer.get(5_000L);
+    private final Timer resetTimer = Timer.get(5_000L); // Cooldown to allow PET disabling before trying to reset again.
 
     // List of gears that restrict the use of other gears when active
     private static final List<PetGear> RESTRICTED_GEARS = List.of(

--- a/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
+++ b/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
@@ -21,7 +21,7 @@ public class PetGearHelper {
     private final PetAPI pet;
     private final ConfigAPI configApi;
     private final SettingsProxy settingsProxy;
-    private final Timer resetTimer = Timer.get(2_000L);
+    private final Timer resetTimer = Timer.get(5_000L);
 
     // List of gears that restrict the use of other gears when active
     private static final List<PetGear> RESTRICTED_GEARS = List.of(

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.11.13",
+	"version": "0.11.14",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Adjust the PetGearHelper reset timer from 2 seconds to 5 seconds to provide a longer stabilization window for pet gear state changes.