### PR TITLE
DSE: fixed NPC targeting when blocked by barriers and fixed PET reset.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/DseGate.java
@@ -146,12 +146,22 @@ public final class DseGate extends GateHandler {
 
         // If we have a guardable NPC and it's the only one left, follow it.
         Npc guardableNpc = this.getGuardableNpc();
-        if (guardableNpc != null && this.module.lootModule.getNpcs().size() == 1) {
+        if (guardableNpc != null && this.npcCount() == 0) {
             StateStore.request(StateStore.State.GUARDING);
             this.module.lootModule.moveToTarget(guardableNpc);
             return true;
         }
         return false; // Allow default logic to take over
+    }
+
+    /**
+     * Counts the number of NPCs that are not guardable one
+     * and can be moved to (not blocked by barriers).
+     */
+    private long npcCount() {
+        return this.module.lootModule.getNpcs().stream()
+                .filter(n -> !this.isGuardableNpc(n) && this.module.movement.canMove(n))
+                .count();
     }
 
     @Override

--- a/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
+++ b/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
@@ -21,7 +21,7 @@ public class PetGearHelper {
     private final PetAPI pet;
     private final ConfigAPI configApi;
     private final SettingsProxy settingsProxy;
-    private final Timer resetTimer = Timer.get(5_000L);
+    private final Timer resetTimer = Timer.get(5_000L); // Cooldown to allow PET disabling before trying to reset again.
 
     // List of gears that restrict the use of other gears when active
     private static final List<PetGear> RESTRICTED_GEARS = List.of(

--- a/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
+++ b/src/main/java/dev/shared/do_gamer/utils/PetGearHelper.java
@@ -21,7 +21,7 @@ public class PetGearHelper {
     private final PetAPI pet;
     private final ConfigAPI configApi;
     private final SettingsProxy settingsProxy;
-    private final Timer resetTimer = Timer.get(2_000L);
+    private final Timer resetTimer = Timer.get(5_000L);
 
     // List of gears that restrict the use of other gears when active
     private static final List<PetGear> RESTRICTED_GEARS = List.of(

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.11.13",
+	"version": "0.11.14",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Adjust NPC guarding logic in DSE gates and tweak PET gear reset timing.

Bug Fixes:
- Ensure guardable NPCs are followed only when no other movable, non-guardable NPCs remain, avoiding issues with targets blocked by barriers.
- Increase PET reset cooldown to prevent rapid, repeated reset attempts after disabling the PET.