### PR TITLE
Add halizeur log overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ We will seek to implement CI/CD in the repository so that developers have a good
 - Orbit Helper Quick Login: Adds a button to navigate to Orbit Helper from the menu. By @orbithelper
 - Simple Galaxy Gate: Supports ABG, Delta, Epsilon, Zeta, Hades, Kuiper, LoW, Invasion, Trinity, DSE, Mimesis and EBG. By @do-gamer
 - Autobuy: Automatically buys boosters and special items from the shop at a configured interval. By @do-gamer
+- Log Overlay: Displays the latest in-game log messages on the canvas (top-center, auto-fade after 5s). Built-in keyword whitelist limits the displayed lines to gains and errors so the canvas does not get cluttered. By @Halizeur
 
 ## Contributing
 

--- a/src/main/java/dev/shared/halizeur/log_overlay/LogOverlay.java
+++ b/src/main/java/dev/shared/halizeur/log_overlay/LogOverlay.java
@@ -128,9 +128,7 @@ public class LogOverlay implements Behavior, Drawable, Listener, Configurable<Lo
     public void onDraw(MapGraphics mg) {
         if (this.config == null || !this.config.enabled) return;
 
-        long now = System.currentTimeMillis();
-        evictExpired(now);
-
+        // Eviction is handled in onTickBehavior() which runs every tick.
         List<String> snapshot;
         synchronized (this.entries) {
             if (this.entries.isEmpty()) return;

--- a/src/main/java/dev/shared/halizeur/log_overlay/LogOverlay.java
+++ b/src/main/java/dev/shared/halizeur/log_overlay/LogOverlay.java
@@ -1,0 +1,160 @@
+package dev.shared.halizeur.log_overlay;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+
+import eu.darkbot.api.PluginAPI;
+import eu.darkbot.api.config.ConfigSetting;
+import eu.darkbot.api.events.EventHandler;
+import eu.darkbot.api.events.Listener;
+import eu.darkbot.api.extensions.Behavior;
+import eu.darkbot.api.extensions.Configurable;
+import eu.darkbot.api.extensions.Draw;
+import eu.darkbot.api.extensions.Drawable;
+import eu.darkbot.api.extensions.Feature;
+import eu.darkbot.api.extensions.MapGraphics;
+import eu.darkbot.api.managers.EventBrokerAPI;
+import eu.darkbot.api.managers.GameLogAPI;
+
+/**
+ * Renders the latest in-game DarkOrbit log messages as an overlay on the
+ * canvas (anchored to the top, no background, auto-fade).
+ *
+ * Source: {@link GameLogAPI.LogMessageEvent} emitted by DarkBot for each
+ * new system message. Each line disappears after DISPLAY_MS ms so the
+ * canvas does not get cluttered.
+ */
+@Feature(name = "Log Overlay",
+         description = "Shows the latest in-game log messages as an overlay on the canvas",
+         enabledByDefault = false)
+@Draw(value = Draw.Stage.OVERLAY)
+public class LogOverlay implements Behavior, Drawable, Listener, Configurable<LogOverlayConfig> {
+
+    private static final int LINE_HEIGHT = 16;
+    private static final int TOP_MARGIN = 30;
+    private static final int MAX_LINES = 5;
+    private static final long DISPLAY_MS = 5000L;
+
+    /**
+     * Case-insensitive keywords that mark a log message as "interesting":
+     * resource / experience / honor gains, or error messages. Anything
+     * else (combat, movement, generic info) is filtered out.
+     */
+    private static final String[] WHITELIST = {
+            // Gains (FR)
+            "gagn", "obtenu", "récup", "recup", "récompense", "recompense",
+            "collect", "ramass",
+            // Gains (EN)
+            "gained", "received", "reward", "earned",
+            // Currencies / resources
+            "uridium", "credit", "crédit", "honor", "honneur",
+            "experience", "expérience", "xp ",
+            "prometium", "endurium", "terbium", "prometid", "duranium",
+            "promerium", "seprom", "xenomit", "palladium",
+            // Boosters / drops
+            "drop", "booster",
+            // Errors (FR)
+            "impossible", "erreur", "échec", "echec", "refusé", "refuse",
+            "plein", "indisponible", "non disponible", "interdit",
+            // Errors (EN)
+            "error", "failed", "refused", "denied", "unavailable", "full",
+            "cannot", "can't"
+    };
+
+    private final Deque<Entry> entries = new ArrayDeque<>();
+    private LogOverlayConfig config;
+
+    public LogOverlay(PluginAPI api) {
+        api.requireAPI(EventBrokerAPI.class).registerListener(this);
+    }
+
+    @Override
+    public void setConfig(ConfigSetting<LogOverlayConfig> cfg) {
+        this.config = cfg.getValue();
+    }
+
+    @Override
+    public void onTickBehavior() {
+        // Evict expired entries even when the canvas is not being redrawn.
+        evictExpired(System.currentTimeMillis());
+    }
+
+    @EventHandler
+    public void onLogMessage(GameLogAPI.LogMessageEvent event) {
+        if (this.config == null || !this.config.enabled) return;
+        String msg = event.getMessage();
+        if (msg == null || msg.isEmpty()) return;
+        if (!isAllowed(msg)) return;
+
+        long expiresAt = System.currentTimeMillis() + DISPLAY_MS;
+        synchronized (this.entries) {
+            this.entries.addLast(new Entry(msg, expiresAt));
+            // If more than MAX_LINES, drop the oldest one so the rest scrolls up.
+            while (this.entries.size() > MAX_LINES) {
+                this.entries.removeFirst();
+            }
+        }
+    }
+
+    /**
+     * Whitelist filter: only display the message if it matches a keyword
+     * from {@link #WHITELIST} (case-insensitive).
+     */
+    private boolean isAllowed(String msg) {
+        String lower = msg.toLowerCase();
+        for (String kw : WHITELIST) {
+            if (lower.contains(kw)) return true;
+        }
+        return false;
+    }
+
+    private void evictExpired(long now) {
+        synchronized (this.entries) {
+            Iterator<Entry> it = this.entries.iterator();
+            while (it.hasNext()) {
+                if (it.next().expiresAtMs <= now) {
+                    it.remove();
+                } else {
+                    break; // entries are ordered chronologically
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onDraw(MapGraphics mg) {
+        if (this.config == null || !this.config.enabled) return;
+
+        long now = System.currentTimeMillis();
+        evictExpired(now);
+
+        List<String> snapshot;
+        synchronized (this.entries) {
+            if (this.entries.isEmpty()) return;
+            snapshot = new ArrayList<>(this.entries.size());
+            for (Entry e : this.entries) snapshot.add(e.text);
+        }
+
+        int cx = mg.getWidthMiddle();
+        int startY = TOP_MARGIN;
+
+        mg.setColor("text_light");
+        for (int i = 0; i < snapshot.size(); i++) {
+            int y = startY + (i + 1) * LINE_HEIGHT;
+            mg.drawString(cx, y, snapshot.get(i), MapGraphics.StringAlign.MID);
+        }
+    }
+
+    private static final class Entry {
+        final String text;
+        final long expiresAtMs;
+
+        Entry(String text, long expiresAtMs) {
+            this.text = text;
+            this.expiresAtMs = expiresAtMs;
+        }
+    }
+}

--- a/src/main/java/dev/shared/halizeur/log_overlay/LogOverlayConfig.java
+++ b/src/main/java/dev/shared/halizeur/log_overlay/LogOverlayConfig.java
@@ -6,6 +6,6 @@ import eu.darkbot.api.config.annotations.Option;
 @Configuration("halizeur.log_overlay.config")
 public class LogOverlayConfig {
 
-    @Option("general.enabled")
+    @Option("halizeur.log_overlay.enabled")
     public boolean enabled = false;
 }

--- a/src/main/java/dev/shared/halizeur/log_overlay/LogOverlayConfig.java
+++ b/src/main/java/dev/shared/halizeur/log_overlay/LogOverlayConfig.java
@@ -1,0 +1,11 @@
+package dev.shared.halizeur.log_overlay;
+
+import eu.darkbot.api.config.annotations.Configuration;
+import eu.darkbot.api.config.annotations.Option;
+
+@Configuration("halizeur.log_overlay.config")
+public class LogOverlayConfig {
+
+    @Option("general.enabled")
+    public boolean enabled = false;
+}

--- a/src/main/resources/dev/shared/lang/strings_en.properties
+++ b/src/main/resources/dev/shared/lang/strings_en.properties
@@ -2,6 +2,10 @@ example.translation=Example translation
 
 general.enabled=Enable
 
+
+# ----- Halizeur : Log Overlay -----
+halizeur.log_overlay.config=Log Overlay
+
 do_gamer.simple_healing.hp_repair=HP Repair (Solace, Orcus, Aegis, Hammerclaw)
 do_gamer.simple_healing.shield_repair=Shield Repair (Aegis, Hammerclaw)
 do_gamer.simple_healing.repair_pod=Repair Pod (Aegis, Hammerclaw)

--- a/src/main/resources/dev/shared/lang/strings_en.properties
+++ b/src/main/resources/dev/shared/lang/strings_en.properties
@@ -5,6 +5,7 @@ general.enabled=Enable
 
 # ----- Halizeur : Log Overlay -----
 halizeur.log_overlay.config=Log Overlay
+halizeur.log_overlay.enabled=Enabled
 
 do_gamer.simple_healing.hp_repair=HP Repair (Solace, Orcus, Aegis, Hammerclaw)
 do_gamer.simple_healing.shield_repair=Shield Repair (Aegis, Hammerclaw)

--- a/src/main/resources/dev/shared/lang/strings_fr.properties
+++ b/src/main/resources/dev/shared/lang/strings_fr.properties
@@ -5,6 +5,7 @@ general.enabled=Activer
 
 # ----- Halizeur : Log Overlay -----
 halizeur.log_overlay.config=Log Overlay
+halizeur.log_overlay.enabled=Activé
 
 do_gamer.simple_healing.hp_repair=Réparation des PV (Solace, Orcus, Aegis, Hammerclaw)
 do_gamer.simple_healing.shield_repair=Réparation du bouclier (Aegis, Hammerclaw)

--- a/src/main/resources/dev/shared/lang/strings_fr.properties
+++ b/src/main/resources/dev/shared/lang/strings_fr.properties
@@ -2,6 +2,10 @@ example.translation=Example translation
 
 general.enabled=Activer
 
+
+# ----- Halizeur : Log Overlay -----
+halizeur.log_overlay.config=Log Overlay
+
 do_gamer.simple_healing.hp_repair=Réparation des PV (Solace, Orcus, Aegis, Hammerclaw)
 do_gamer.simple_healing.shield_repair=Réparation du bouclier (Aegis, Hammerclaw)
 do_gamer.simple_healing.repair_pod=Capsule de réparation (Aegis, Hammerclaw)

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -18,7 +18,8 @@
 		"dev.shared.orbithelper.behaviours.GGAlertCloser",
 		"dev.shared.orbithelper.behaviours.fast_travel.FastTravel",
 		"dev.shared.do_gamer.module.simple_galaxy_gate.SimpleGalaxyGate",
-		"dev.shared.do_gamer.task.autobuy.Autobuy"
+		"dev.shared.do_gamer.task.autobuy.Autobuy",
+		"dev.shared.halizeur.log_overlay.LogOverlay"
 	],
 	"update": "https://raw.githubusercontent.com/Darkbot-Plugins/SharedPlugin/main/src/main/resources/plugin.json",
 	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/latest/download/SharedPlugin.jar"

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.11.14",
+	"version": "0.12.0",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
Drawable + Behavior + Listener feature that displays the latest in-game log messages on the canvas, anchored top-center, fading out after 5 seconds. Built-in keyword whitelist limits the displayed lines to gains and errors, so the canvas does not get cluttered.

Disabled by default. Single 'enabled' checkbox in the config.

## Summary by Sourcery

Add an optional in-game log overlay feature that displays recent filtered log messages on the game canvas.

New Features:
- Introduce a log overlay feature that renders recent DarkOrbit log messages as an on-canvas overlay, anchored at the top center and limited to a small number of lines.
- Add configuration support with an enable/disable toggle for the log overlay feature.

Enhancements:
- Filter displayed log messages using a keyword whitelist to focus on gains and error-related entries and avoid clutter.
- Add localization keys for the log overlay configuration label in English and French.