### PR TITLE
Trinity: configurable gate / difficulty + fallback on failed launch

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/SimpleGalaxyGateConfig.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/SimpleGalaxyGateConfig.java
@@ -85,6 +85,9 @@ public final class SimpleGalaxyGateConfig {
     @Option("do_gamer.simple_galaxy_gate.eternal_blacklight")
     public EternalBlacklightSettings eternalBlacklight = new EternalBlacklightSettings();
 
+    @Option("do_gamer.simple_galaxy_gate.trinity_trials")
+    public TrinityTrialsSettings trinityTrials = new TrinityTrialsSettings();
+
     @Option("do_gamer.simple_galaxy_gate.kamikaze")
     public KamikazeSettings kamikaze = new KamikazeSettings();
 
@@ -323,6 +326,71 @@ public final class SimpleGalaxyGateConfig {
 
         }
 
+    }
+
+    /**
+     * Settings specific to the Trinity Trials gate.
+     */
+    public static class TrinityTrialsSettings {
+        public static class Instructions extends ConfigHtmlInstructions {
+            @Override
+            public String getEditorValue() {
+                return this.buildList(null,
+                        "Gate: which available portal to enter (1st = Arène Magma slot, 2nd = next).",
+                        "Difficulty: clicked in the difficulty dropdown before launching.",
+                        "Fallback: when a run fails to start, retry one notch lower, then switch gate.");
+            }
+        }
+
+        @Option("")
+        @Readonly
+        @Editor(Instructions.class)
+        public String instructions = null;
+
+        @Option("do_gamer.simple_galaxy_gate.trinity_trials.gate_choice")
+        @Number(min = 1, max = 4, step = 1)
+        public int gateChoice = 1;
+
+        @Option("do_gamer.simple_galaxy_gate.trinity_trials.difficulty")
+        @Dropdown(options = TrinityDifficultyDropdown.class)
+        public TrinityDifficulty difficulty = TrinityDifficulty.NORMAL;
+
+        @Option("do_gamer.simple_galaxy_gate.trinity_trials.fallback_on_failure")
+        public boolean fallbackOnFailure = true;
+
+        public enum TrinityDifficulty {
+            FACILE(1, "Facile"),
+            NORMAL(2, "Normal"),
+            DIFFICILE(3, "Difficile"),
+            EXPERT(4, "Expert"),
+            CAUCHEMAR(5, "Cauchemar");
+
+            public final int dropdownIndex;
+            public final String label;
+
+            TrinityDifficulty(int dropdownIndex, String label) {
+                this.dropdownIndex = dropdownIndex;
+                this.label = label;
+            }
+
+            public TrinityDifficulty oneStepEasier() {
+                int idx = ordinal();
+                return idx > 0 ? values()[idx - 1] : null;
+            }
+        }
+
+        public static class TrinityDifficultyDropdown
+                implements Dropdown.Options<TrinityDifficulty> {
+            @Override
+            public List<TrinityDifficulty> options() {
+                return List.of(TrinityDifficulty.values());
+            }
+
+            @Override
+            public String getText(TrinityDifficulty option) {
+                return option == null ? "" : option.label;
+            }
+        }
     }
 
     /**

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/TrinityTrialsGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/TrinityTrialsGate.java
@@ -1,11 +1,10 @@
 package dev.shared.do_gamer.module.simple_galaxy_gate.gate;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
 import java.util.regex.Pattern;
 
 import dev.shared.do_gamer.module.simple_galaxy_gate.StateStore;
-import dev.shared.do_gamer.utils.ServerTimeHelper;
+import dev.shared.do_gamer.module.simple_galaxy_gate.config.SimpleGalaxyGateConfig.TrinityTrialsSettings;
+import dev.shared.do_gamer.module.simple_galaxy_gate.config.SimpleGalaxyGateConfig.TrinityTrialsSettings.TrinityDifficulty;
 import eu.darkbot.api.game.other.GameMap;
 import eu.darkbot.api.game.other.Gui;
 import eu.darkbot.util.Timer;
@@ -14,12 +13,43 @@ public final class TrinityTrialsGate extends GateHandler {
     private static final String DIFFICULTY_SELECT_GUI = "trinitytrials_difficultyselect";
     private static final int PORTAL_TYPE_ID = 304; // Portal type ID for Trinity Trials
     private static final Pattern MAP_PATTERN = Pattern.compile("^[1-5]-[1-4]$");
-    private Timer clickTimer = Timer.get(10_000L);
+
+    /** Click coordinates inside the difficulty-select GUI. */
+    private static final int GATE_DROPDOWN_X = 360;
+    private static final int GATE_DROPDOWN_Y = 225;
+    private static final int DIFFICULTY_DROPDOWN_X = 360;
+    private static final int DIFFICULTY_DROPDOWN_Y = 270;
+    private static final int DROPDOWN_ITEM_STRIDE = 17;
+    private static final int GO_BUTTON_X = 305;
+    private static final int GO_BUTTON_Y = 345;
+
+    /** Number of "Go" attempts before triggering fallback / giving up. */
+    private static final int MAX_GO_CLICKS = 3;
+
+    private final Timer clickTimer = Timer.get(10_000L);
+    private final Timer selectTimer = Timer.get(1_000L);
     private int clickCount = 0;
-    private boolean trySelectSecondGate = false;
-    private Timer selectTimer = Timer.get(1_000L);
-    private int selectStep = 0;
     private boolean setFlags = false;
+
+    /** Selection-step machine for the GUI:
+     *   0 = open gate dropdown
+     *   1 = click gate item
+     *   2 = open difficulty dropdown
+     *   3 = click difficulty item
+     *   4 = ready to click "Go"
+     */
+    private int selectStep = 0;
+    private boolean selectionComplete = false;
+
+    /** Effective gate / difficulty for the current run — start from config
+     *  values and degrade through fallback when a run fails to start. */
+    private int activeGateIndex = 0;
+    private TrinityDifficulty activeDifficulty = null;
+    private boolean triedAlternateGate = false;
+
+    /** Difficulty of the last successfully completed run, surfaced in
+     *  the status bar so the user can see whether a fallback kicked in. */
+    private TrinityDifficulty lastCompletedDifficulty = null;
 
     public TrinityTrialsGate() {
         this.npcMap.put("..::{ Pyrospire }::..", new NpcParam(620.0));
@@ -32,15 +62,12 @@ public final class TrinityTrialsGate extends GateHandler {
 
     @Override
     public boolean prepareTickModule() {
+        ensureRunPlanInitialized();
         // Max clicks reached
-        if (this.clickCount >= 3) {
-            if (this.isSunday() && !this.trySelectSecondGate) {
-                // Set flag to try selecting second gate and reset counters
-                this.trySelectSecondGate = true;
-                this.clickCount = 0;
-                this.selectStep = 0;
-                return true; // Try selecting second gate
-            }
+        if (this.clickCount >= MAX_GO_CLICKS) {
+            // Try fallback (lower difficulty, then alternate gate) before giving up
+            if (tryFallback()) return true;
+
             if (!this.setFlags) {
                 this.setFlags = true; // Ensure flags are only set once
                 this.module.setShouldMoveToRefinery(true);
@@ -52,6 +79,7 @@ public final class TrinityTrialsGate extends GateHandler {
         // Handle GUI interaction or traveling to gate
         if (this.handleGui() || this.handleTravelToGate(PORTAL_TYPE_ID)) {
             StateStore.request(StateStore.State.TRAVELING_TO_GATE);
+            updateStatus();
             return true;
         }
         return false;
@@ -59,7 +87,11 @@ public final class TrinityTrialsGate extends GateHandler {
 
     @Override
     public boolean collectTickModule() {
+        if (this.activeDifficulty != null) {
+            this.lastCompletedDifficulty = this.activeDifficulty;
+        }
         this.reset();
+        updateStatus();
         this.closeGui(DIFFICULTY_SELECT_GUI);
         return false;
     }
@@ -67,10 +99,13 @@ public final class TrinityTrialsGate extends GateHandler {
     @Override
     public void reset() {
         // Reset states
-        this.trySelectSecondGate = false;
         this.selectStep = 0;
+        this.selectionComplete = false;
         this.clickCount = 0;
         this.setFlags = false;
+        this.activeDifficulty = null;
+        this.activeGateIndex = 0;
+        this.triedAlternateGate = false;
         if (this.clickTimer.isArmed()) {
             this.clickTimer.disarm();
         }
@@ -84,8 +119,56 @@ public final class TrinityTrialsGate extends GateHandler {
         return this.getFactionMapForTravel(toLowMap ? 1 : 8); // travel to map x-1 or x-8
     }
 
+    /** Initializes the active gate / difficulty from config on the first
+     *  GUI tick of a new run. Subsequent ticks reuse those values until
+     *  collect/reset, possibly stepped down by {@link #tryFallback()}. */
+    private void ensureRunPlanInitialized() {
+        if (this.activeDifficulty != null && this.activeGateIndex > 0) return;
+        TrinityTrialsSettings cfg = this.module.getConfig().trinityTrials;
+        this.activeDifficulty = cfg.difficulty != null ? cfg.difficulty : TrinityDifficulty.NORMAL;
+        this.activeGateIndex = Math.max(1, cfg.gateChoice);
+    }
+
     /**
-     * Handles the gate select GUI interaction
+     * Step down the run plan one notch when 3 "Go" clicks failed: first
+     * try a lower difficulty, then switch to the alternate gate. Returns
+     * true if a retry was set up; false if we ran out of fallbacks.
+     */
+    private boolean tryFallback() {
+        if (!this.module.getConfig().trinityTrials.fallbackOnFailure) return false;
+
+        TrinityDifficulty easier = this.activeDifficulty != null
+                ? this.activeDifficulty.oneStepEasier()
+                : null;
+        if (easier != null) {
+            this.activeDifficulty = easier;
+            restartSelection();
+            return true;
+        }
+        if (!this.triedAlternateGate) {
+            this.triedAlternateGate = true;
+            this.activeGateIndex = (this.activeGateIndex == 1) ? 2 : 1;
+            this.activeDifficulty = this.module.getConfig().trinityTrials.difficulty;
+            restartSelection();
+            return true;
+        }
+        return false;
+    }
+
+    private void restartSelection() {
+        this.selectStep = 0;
+        this.selectionComplete = false;
+        this.clickCount = 0;
+        if (this.clickTimer.isArmed()) {
+            this.clickTimer.disarm();
+        }
+    }
+
+    /**
+     * Drives the difficulty-select GUI: opens both dropdowns, clicks the
+     * configured gate and difficulty, then clicks the "Go" button. The
+     * selectStep state machine guarantees one click per tick with a
+     * 1-second pause between clicks for the UI to settle.
      */
     private boolean handleGui() {
         return this.getVisibleGui(DIFFICULTY_SELECT_GUI).map(gui -> {
@@ -94,13 +177,14 @@ public final class TrinityTrialsGate extends GateHandler {
                 this.clickTimer.activate(3_000L);
                 return true;
             }
-            // Selecting second gate
-            if (this.trySelectSecondGate && this.selectGateType(gui, 2)) {
+            // Selecting gate + difficulty
+            if (!this.selectionComplete) {
+                runSelectionStep(gui);
                 return true;
             }
             // Click "Go" button if timer allows
             if (this.clickTimer.isInactive()) {
-                gui.click(305, 345);
+                gui.click(GO_BUTTON_X, GO_BUTTON_Y);
                 this.clickTimer.activate();
                 this.clickCount++;
             }
@@ -108,31 +192,56 @@ public final class TrinityTrialsGate extends GateHandler {
         }).orElse(false);
     }
 
-    /**
-     * Handles the gate type selection process
-     */
-    private boolean selectGateType(Gui gui, int index) {
+    private void runSelectionStep(Gui gui) {
         switch (this.selectStep) {
             case 0:
-                gui.click(360, 225); // open select
+                gui.click(GATE_DROPDOWN_X, GATE_DROPDOWN_Y); // open gate select
                 this.selectTimer.activate();
                 this.selectStep = 1;
-                return true;
+                return;
             case 1:
                 if (this.selectTimer.isInactive()) {
-                    gui.click(360, 225 + 17 * index); // select gate type
+                    gui.click(GATE_DROPDOWN_X,
+                            GATE_DROPDOWN_Y + DROPDOWN_ITEM_STRIDE * this.activeGateIndex); // select gate type
                     this.selectTimer.activate();
                     this.selectStep = 2;
                 }
-                return true;
+                return;
+            case 2:
+                if (this.selectTimer.isInactive()) {
+                    gui.click(DIFFICULTY_DROPDOWN_X, DIFFICULTY_DROPDOWN_Y); // open difficulty select
+                    this.selectTimer.activate();
+                    this.selectStep = 3;
+                }
+                return;
+            case 3:
+                if (this.selectTimer.isInactive()) {
+                    gui.click(DIFFICULTY_DROPDOWN_X,
+                            DIFFICULTY_DROPDOWN_Y
+                                    + DROPDOWN_ITEM_STRIDE * this.activeDifficulty.dropdownIndex); // select difficulty
+                    this.selectTimer.activate();
+                    this.selectStep = 4;
+                }
+                return;
             default:
                 // Wait for select timer to finish before allowing next action
-                return this.selectTimer.isActive();
+                if (this.selectTimer.isInactive()) {
+                    this.selectionComplete = true;
+                }
+                return;
         }
     }
 
-    private boolean isSunday() {
-        LocalDateTime now = ServerTimeHelper.currentDateTime();
-        return now.getDayOfWeek() == DayOfWeek.SUNDAY;
+    private void updateStatus() {
+        StringBuilder sb = new StringBuilder();
+        if (this.activeDifficulty != null && this.activeGateIndex > 0) {
+            sb.append("gate ").append(this.activeGateIndex)
+              .append(" / ").append(this.activeDifficulty.label);
+        }
+        if (this.lastCompletedDifficulty != null) {
+            if (sb.length() > 0) sb.append(" | ");
+            sb.append("last: ").append(this.lastCompletedDifficulty.label);
+        }
+        this.statusDetails = sb.length() > 0 ? sb.toString() : null;
     }
 }

--- a/src/main/resources/dev/shared/lang/strings_en.properties
+++ b/src/main/resources/dev/shared/lang/strings_en.properties
@@ -142,6 +142,13 @@ do_gamer.simple_galaxy_gate.eternal_blacklight.boosters=Boosters
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.auto_select=Auto-select
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.auto_select.desc=Selects boosters by lowest configured priority, then by highest booster effectiveness percentage.
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.priority=Priority
+do_gamer.simple_galaxy_gate.trinity_trials=Trinity Trials Settings
+do_gamer.simple_galaxy_gate.trinity_trials.gate_choice=Gate choice
+do_gamer.simple_galaxy_gate.trinity_trials.gate_choice.desc=Index of the portal to enter in the "Choix de portail" dropdown (1 = first available, 2 = second).
+do_gamer.simple_galaxy_gate.trinity_trials.difficulty=Difficulty
+do_gamer.simple_galaxy_gate.trinity_trials.difficulty.desc=Difficulty selected in the "Choix de difficulté" dropdown before launching.
+do_gamer.simple_galaxy_gate.trinity_trials.fallback_on_failure=Fallback on failure
+do_gamer.simple_galaxy_gate.trinity_trials.fallback_on_failure.desc=When 3 launch attempts fail, retry one difficulty lower; if already at the lowest, switch to the alternate gate.
 do_gamer.simple_galaxy_gate.kamikaze=Kamikaze Settings
 do_gamer.simple_galaxy_gate.kamikaze.desc=Required PET to have equipped Kamikaze gear, PET HP less than 20% and added extra flag Kamikaze to NPC.
 do_gamer.simple_galaxy_gate.kamikaze.min_npcs=Minimum NPCs

--- a/src/main/resources/dev/shared/lang/strings_fr.properties
+++ b/src/main/resources/dev/shared/lang/strings_fr.properties
@@ -142,6 +142,13 @@ do_gamer.simple_galaxy_gate.eternal_blacklight.boosters=Boosters
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.auto_select=Auto-select
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.auto_select.desc=Selects boosters by lowest configured priority, then by highest booster effectiveness percentage.
 do_gamer.simple_galaxy_gate.eternal_blacklight.boosters.priority=Priority
+do_gamer.simple_galaxy_gate.trinity_trials=Paramètres Épreuves de la Trinité
+do_gamer.simple_galaxy_gate.trinity_trials.gate_choice=Choix du portail
+do_gamer.simple_galaxy_gate.trinity_trials.gate_choice.desc=Index du portail à entrer dans le menu "Choix de portail" (1 = premier dispo, 2 = second).
+do_gamer.simple_galaxy_gate.trinity_trials.difficulty=Difficulté
+do_gamer.simple_galaxy_gate.trinity_trials.difficulty.desc=Difficulté sélectionnée dans "Choix de difficulté" avant de lancer.
+do_gamer.simple_galaxy_gate.trinity_trials.fallback_on_failure=Fallback en cas d'échec
+do_gamer.simple_galaxy_gate.trinity_trials.fallback_on_failure.desc=Après 3 lancements échoués, retente avec une difficulté plus basse ; si déjà au minimum, bascule sur l'autre portail.
 do_gamer.simple_galaxy_gate.kamikaze=Paramètres Kamikaze
 do_gamer.simple_galaxy_gate.kamikaze.desc=Le PET doit avoir l'équipement Kamikaze, moins de 20 % de HP et le NPC doit avoir le drapeau supplémentaire Kamikaze.
 do_gamer.simple_galaxy_gate.kamikaze.min_npcs=Nombre minimum de NPC


### PR DESCRIPTION
- Add TrinityTrialsSettings (gate index 1-4, difficulty enum, fallback flag).
- Drive both dropdowns (gate + difficulty) before clicking "C'est parti !" instead of only the gate-type select on Sundays.
- On 3 failed "Go" clicks, retry one difficulty lower; if already at the easiest, switch to the alternate gate before deferring to refinery / profile switch.
- Surface active and last-completed difficulty in the gate status line.

## Summary by Sourcery

Add configurable Trinity Trials gate and difficulty selection with an automatic fallback strategy when launches fail, and surface the active/last difficulty in the gate status.

New Features:
- Introduce Trinity Trials configuration including gate choice, difficulty selection, and an optional fallback-on-failure behavior.
- Automatically drive both the gate and difficulty dropdowns in the Trinity Trials GUI before starting a run.

Enhancements:
- Implement a retry/fallback flow that steps down difficulty and optionally switches gate after repeated failed launch attempts.
- Expose current and last-completed Trinity Trials difficulty in the gate status details for better visibility.

Documentation:
- Add localized English and French labels and descriptions for Trinity Trials settings in the configuration UI.