### PR TITLE
Add auto PET fuel buyer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ We will seek to implement CI/CD in the repository so that developers have a good
 - Simple Galaxy Gate: Supports ABG, Delta, Epsilon, Zeta, Hades, Kuiper, LoW, Invasion, Trinity, DSE, Mimesis and EBG. By @do-gamer
 - Autobuy: Automatically buys boosters and special items from the shop at a configured interval. By @do-gamer
 - Log Overlay: Displays the latest in-game log messages on the canvas (top-center, auto-fade after 5s). Built-in keyword whitelist limits the displayed lines to gains and errors so the canvas does not get cluttered. By @Halizeur
+- Auto PET Fuel Buyer: Automatically buys PET fuel when it reaches a configured amount. By @Maxim
 
 ## Contributing
 

--- a/src/main/java/dev/shared/maxim/petfuel/AutoPetFuelBuyer.java
+++ b/src/main/java/dev/shared/maxim/petfuel/AutoPetFuelBuyer.java
@@ -1,0 +1,175 @@
+package dev.shared.maxim.petfuel;
+
+import dev.shared.maxim.petfuel.config.PetFuelConfig;
+import eu.darkbot.api.PluginAPI;
+import eu.darkbot.api.config.ConfigSetting;
+import eu.darkbot.api.extensions.Configurable;
+import eu.darkbot.api.extensions.Feature;
+import eu.darkbot.api.extensions.InstructionProvider;
+import eu.darkbot.api.extensions.Task;
+import eu.darkbot.api.game.items.Item;
+import eu.darkbot.api.game.items.ItemCategory;
+import eu.darkbot.api.managers.BackpageAPI;
+import eu.darkbot.api.managers.HeroItemsAPI;
+import eu.darkbot.api.managers.StatsAPI;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+@Feature(name = "Auto PET Fuel Buyer", description = "Automatically buys PET fuel when it reaches a configured amount.")
+public final class AutoPetFuelBuyer implements Task, Configurable<PetFuelConfig>, InstructionProvider {
+
+    private static final String PET_FUEL_ITEM_ID = "resource_pet-fuel";
+    private static final String SHOP_ENDPOINT = "ajax/shop.php";
+    private static final String SHOP_CATEGORY = "petGear";
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+
+    private final BackpageAPI backpage;
+    private final HeroItemsAPI heroItems;
+    private final StatsAPI stats;
+    private final JLabel statusLabel = new JLabel("Auto PET Fuel Buyer: waiting");
+
+    private PetFuelConfig config;
+    private long nextActionAt;
+
+    public AutoPetFuelBuyer(PluginAPI api) {
+        this.backpage = api.requireAPI(BackpageAPI.class);
+        this.heroItems = api.requireAPI(HeroItemsAPI.class);
+        this.stats = api.requireAPI(StatsAPI.class);
+    }
+
+    @Override
+    public void setConfig(ConfigSetting<PetFuelConfig> setting) {
+        this.config = setting.getValue();
+    }
+
+    @Override
+    public JComponent beforeConfig() {
+        return this.statusLabel;
+    }
+
+    @Override
+    public void onTickTask() {
+        // Backpage requests run on the background tick.
+    }
+
+    @Override
+    public void onBackgroundTick() {
+        if (this.config == null || !this.config.enabled) {
+            this.setStatus("disabled");
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        if (now < this.nextActionAt) {
+            return;
+        }
+
+        if (!this.isBackpageReady()) {
+            this.setStatus("waiting for valid SID");
+            this.scheduleRetry(now);
+            return;
+        }
+
+        Optional<Double> currentFuel = this.readCurrentFuel();
+        if (!currentFuel.isPresent()) {
+            this.setStatus("waiting for PET fuel inventory");
+            this.scheduleRetry(now);
+            return;
+        }
+
+        PetFuelPlanner.Plan plan = PetFuelPlanner.plan(
+                currentFuel.get(),
+                this.config.minFuel,
+                this.config.buyAmount,
+                this.config.minUridiumReserve,
+                this.stats.getTotalUridium());
+
+        switch (plan.action) {
+            case SKIP_ENOUGH_FUEL:
+                this.setStatus(String.format("fuel %,.0f, next check in %d min", currentFuel.get(), this.config.checkIntervalMinutes));
+                this.scheduleNextCheck(now);
+                return;
+            case SKIP_NOT_ENOUGH_URI:
+                this.setStatus(String.format("not enough uri, needs ~%,.0f", plan.uridiumCost));
+                this.scheduleNextCheck(now);
+                return;
+            case BUY:
+                this.tryBuy(plan, now);
+                return;
+            default:
+                this.scheduleRetry(now);
+        }
+    }
+
+    private boolean isBackpageReady() {
+        return this.backpage.isInstanceValid()
+                && this.backpage.getSidStatus() != null
+                && this.backpage.getSidStatus().contains("OK");
+    }
+
+    private Optional<Double> readCurrentFuel() {
+        try {
+            for (Item item : this.heroItems.getItems(ItemCategory.PET)) {
+                if (PET_FUEL_ITEM_ID.equals(item.getId())) {
+                    return Optional.of(item.getQuantity());
+                }
+            }
+        } catch (Exception ignored) {
+            return Optional.empty();
+        }
+        return Optional.empty();
+    }
+
+    private void tryBuy(PetFuelPlanner.Plan plan, long now) {
+        try {
+            this.buyPetFuel(plan.amountToBuy);
+            this.setStatus(String.format("bought %,d PET fuel for ~%,.0f uri", plan.amountToBuy, plan.uridiumCost));
+            this.log("Bought %,d PET fuel for ~%,.0f uri", plan.amountToBuy, plan.uridiumCost);
+            this.scheduleNextCheck(now);
+        } catch (IOException e) {
+            this.setStatus("shop request failed, retrying");
+            this.log("PET fuel shop request failed: %s", e.getMessage());
+            this.scheduleRetry(now);
+        }
+    }
+
+    private void buyPetFuel(int amount) throws IOException {
+        HttpURLConnection connection = this.backpage.postHttp(SHOP_ENDPOINT, 3_000)
+                .setParam("action", "purchase")
+                .setParam("category", SHOP_CATEGORY)
+                .setParam("itemId", PET_FUEL_ITEM_ID)
+                .setParam("amount", amount)
+                .setParam("selectedName", "")
+                .setParam("level", "")
+                .getConnection();
+
+        int responseCode = connection.getResponseCode();
+        if (responseCode != HttpURLConnection.HTTP_OK) {
+            throw new IOException("HTTP " + responseCode);
+        }
+    }
+
+    private void scheduleNextCheck(long now) {
+        this.nextActionAt = now + Math.max(1, this.config.checkIntervalMinutes) * 60_000L;
+    }
+
+    private void scheduleRetry(long now) {
+        this.nextActionAt = now + Math.max(5, this.config.retryDelaySeconds) * 1_000L;
+    }
+
+    private void setStatus(String status) {
+        this.statusLabel.setText("[" + LocalTime.now().format(TIME_FORMAT) + "] Auto PET Fuel Buyer: " + status);
+    }
+
+    private void log(String message, Object... args) {
+        if (this.config != null && this.config.verboseLogging) {
+            System.out.println("[Auto PET Fuel Buyer] " + String.format(message, args));
+        }
+    }
+}

--- a/src/main/java/dev/shared/maxim/petfuel/PetFuelPlanner.java
+++ b/src/main/java/dev/shared/maxim/petfuel/PetFuelPlanner.java
@@ -1,0 +1,40 @@
+package dev.shared.maxim.petfuel;
+
+public final class PetFuelPlanner {
+
+    public static final double PET_FUEL_URI_COST = 0.25D;
+
+    private PetFuelPlanner() {
+    }
+
+    public static Plan plan(double currentFuel, int minFuel, int buyAmount, int minUridiumReserve, double availableUridium) {
+        if (currentFuel > minFuel) {
+            return new Plan(Action.SKIP_ENOUGH_FUEL, 0, 0D);
+        }
+
+        double cost = buyAmount * PET_FUEL_URI_COST;
+        if (availableUridium - cost < minUridiumReserve) {
+            return new Plan(Action.SKIP_NOT_ENOUGH_URI, 0, cost);
+        }
+
+        return new Plan(Action.BUY, buyAmount, cost);
+    }
+
+    public enum Action {
+        BUY,
+        SKIP_ENOUGH_FUEL,
+        SKIP_NOT_ENOUGH_URI
+    }
+
+    public static final class Plan {
+        public final Action action;
+        public final int amountToBuy;
+        public final double uridiumCost;
+
+        private Plan(Action action, int amountToBuy, double uridiumCost) {
+            this.action = action;
+            this.amountToBuy = amountToBuy;
+            this.uridiumCost = uridiumCost;
+        }
+    }
+}

--- a/src/main/java/dev/shared/maxim/petfuel/config/PetFuelConfig.java
+++ b/src/main/java/dev/shared/maxim/petfuel/config/PetFuelConfig.java
@@ -1,0 +1,35 @@
+package dev.shared.maxim.petfuel.config;
+
+import eu.darkbot.api.config.annotations.Configuration;
+import eu.darkbot.api.config.annotations.Number;
+import eu.darkbot.api.config.annotations.Option;
+
+@Configuration("maxim.pet_fuel")
+public class PetFuelConfig {
+
+    @Option("general.enabled")
+    public boolean enabled = true;
+
+    @Option("maxim.pet_fuel.min_fuel")
+    @Number(min = 0, max = 1_000_000, step = 500)
+    public int minFuel = 5_000;
+
+    @Option("maxim.pet_fuel.buy_amount")
+    @Number(min = 100, max = 100_000, step = 100)
+    public int buyAmount = 4_000;
+
+    @Option("maxim.pet_fuel.min_uri_reserve")
+    @Number(min = 0, max = 10_000_000, step = 500)
+    public int minUridiumReserve = 2_000;
+
+    @Option("maxim.pet_fuel.check_interval")
+    @Number(min = 1, max = 1_440, step = 1)
+    public int checkIntervalMinutes = 15;
+
+    @Option("maxim.pet_fuel.retry_delay")
+    @Number(min = 5, max = 600, step = 5)
+    public int retryDelaySeconds = 60;
+
+    @Option("maxim.pet_fuel.verbose")
+    public boolean verboseLogging = true;
+}

--- a/src/main/resources/dev/shared/lang/strings_en.properties
+++ b/src/main/resources/dev/shared/lang/strings_en.properties
@@ -234,3 +234,16 @@ do_gamer.autobuy.ammo.slugElsD01=ELS-D01 (Slug)
 do_gamer.autobuy.purchase.amount=Purchase amount
 do_gamer.autobuy.purchase.min= Min in inventory
 do_gamer.autobuy.purchase.min.desc=Minimum amount of the item in inventory to trigger the purchase.
+
+maxim.pet_fuel=Auto PET Fuel Buyer
+maxim.pet_fuel.min_fuel=Buy when PET fuel is at or below
+maxim.pet_fuel.min_fuel.desc=The plugin buys fuel once current PET fuel reaches this amount or lower.
+maxim.pet_fuel.buy_amount=Fuel amount to buy
+maxim.pet_fuel.buy_amount.desc=Amount of PET fuel to buy per purchase.
+maxim.pet_fuel.min_uri_reserve=Minimum uridium reserve
+maxim.pet_fuel.min_uri_reserve.desc=Do not buy if the purchase would leave less uridium than this reserve.
+maxim.pet_fuel.check_interval=Check interval (minutes)
+maxim.pet_fuel.check_interval.desc=How often to check fuel after a normal cycle.
+maxim.pet_fuel.retry_delay=Retry delay (seconds)
+maxim.pet_fuel.retry_delay.desc=How long to wait after inventory/SID/shop errors.
+maxim.pet_fuel.verbose=Verbose logging

--- a/src/main/resources/dev/shared/lang/strings_es.properties
+++ b/src/main/resources/dev/shared/lang/strings_es.properties
@@ -234,3 +234,16 @@ do_gamer.autobuy.ammo.slugElsD01=ELS-D01 (Slug)
 do_gamer.autobuy.purchase.amount=Purchase amount
 do_gamer.autobuy.purchase.min= Min in inventory
 do_gamer.autobuy.purchase.min.desc=Minimum amount of the item in inventory to trigger the purchase.
+
+maxim.pet_fuel=Comprador automatico de combustible PET
+maxim.pet_fuel.min_fuel=Comprar cuando el combustible PET sea menor o igual a
+maxim.pet_fuel.min_fuel.desc=El plugin compra combustible cuando el combustible PET actual llega a esta cantidad o menos.
+maxim.pet_fuel.buy_amount=Cantidad de combustible a comprar
+maxim.pet_fuel.buy_amount.desc=Cantidad de combustible PET a comprar por cada compra.
+maxim.pet_fuel.min_uri_reserve=Reserva minima de uridium
+maxim.pet_fuel.min_uri_reserve.desc=No compra si la compra dejaria menos uridium que esta reserva.
+maxim.pet_fuel.check_interval=Intervalo de comprobacion (minutos)
+maxim.pet_fuel.check_interval.desc=Cada cuanto comprobar combustible despues de un ciclo normal.
+maxim.pet_fuel.retry_delay=Espera para reintentar (segundos)
+maxim.pet_fuel.retry_delay.desc=Tiempo de espera despues de errores de inventario, SID o tienda.
+maxim.pet_fuel.verbose=Registro detallado

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -19,7 +19,8 @@
 		"dev.shared.orbithelper.behaviours.fast_travel.FastTravel",
 		"dev.shared.do_gamer.module.simple_galaxy_gate.SimpleGalaxyGate",
 		"dev.shared.do_gamer.task.autobuy.Autobuy",
-		"dev.shared.halizeur.log_overlay.LogOverlay"
+		"dev.shared.halizeur.log_overlay.LogOverlay",
+		"dev.shared.maxim.petfuel.AutoPetFuelBuyer"
 	],
 	"update": "https://raw.githubusercontent.com/Darkbot-Plugins/SharedPlugin/main/src/main/resources/plugin.json",
 	"download": "https://github.com/Darkbot-Plugins/SharedPlugin/releases/latest/download/SharedPlugin.jar"


### PR DESCRIPTION
﻿## Summary
- Adds an Auto PET Fuel Buyer feature under `dev.shared.maxim.petfuel`.
- Buys `resource_pet-fuel` from the backpage shop when PET fuel is at or below the configured threshold.
- Adds configurable buy amount, minimum uridium reserve, check interval, retry delay, and verbose logging.
- Registers English and Spanish config labels and adds the feature to `plugin.json` and README.

## Notes
- The feature uses DarkBot's `BackpageAPI`, `HeroItemsAPI`, and `StatsAPI` only.
- No compiled jar is included; maintainers can build/sign the release through the normal SharedPlugin flow.

## Validation
- Compiled the new feature classes locally with `javac -source 11 -target 11` against local `DarkBot.jar`.
- Could not run full Gradle build in this checkout because `gradle-wrapper.jar` is absent and no global `gradle` command is installed.

## Summary by Sourcery

Add an Auto PET Fuel Buyer feature that automatically purchases PET fuel from the shop based on configurable thresholds and timing, and expose it in the plugin configuration and documentation.

New Features:
- Introduce an Auto PET Fuel Buyer task that monitors PET fuel and purchases more when it falls below a configured amount while respecting a minimum uridium reserve.
- Add a dedicated PET fuel purchase planner to decide whether to buy based on current fuel and uridium levels.
- Provide configuration options for PET fuel thresholds, purchase amounts, uridium reserve, check intervals, retry delays, and verbose logging.

Enhancements:
- Register English and Spanish localization entries for the Auto PET Fuel Buyer configuration labels.
- Document the Auto PET Fuel Buyer feature in the README so users can discover and enable it.