### PR TITLE
Added option to restrict Crowd Avoidance to preferred zones.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/behaviour/CrowdAvoidance.java
+++ b/src/main/java/dev/shared/do_gamer/behaviour/CrowdAvoidance.java
@@ -103,6 +103,11 @@ public class CrowdAvoidance implements Behavior, Configurable<CrowdAvoidanceConf
             return false;
         }
 
+        // Keep inactive if restricted to preferred zones and hero is not in one
+        if (this.config.other.onlyInPreferredZone && !this.movement.isInPreferredZone(this.hero)) {
+            return false;
+        }
+
         return this.config.consider.npcs || this.config.consider.enemies || this.config.consider.allies;
     }
 

--- a/src/main/java/dev/shared/do_gamer/config/CrowdAvoidanceConfig.java
+++ b/src/main/java/dev/shared/do_gamer/config/CrowdAvoidanceConfig.java
@@ -43,5 +43,8 @@ public class CrowdAvoidanceConfig {
     public static class OtherConfig {
         @Option("do_gamer.crowd_avoidance.other.run_mode")
         public boolean runMode = false;
+
+        @Option("do_gamer.crowd_avoidance.other.only_in_preferred_zone")
+        public boolean onlyInPreferredZone = false;
     }
 }

--- a/src/main/resources/dev/shared/lang/strings_en.properties
+++ b/src/main/resources/dev/shared/lang/strings_en.properties
@@ -114,6 +114,8 @@ do_gamer.crowd_avoidance.avoid_draw_fire.use_emp=Additionally use EMP-01
 do_gamer.crowd_avoidance.other=Other settings
 do_gamer.crowd_avoidance.other.run_mode=Use Run config during avoidance
 do_gamer.crowd_avoidance.other.run_mode.desc=When enabled, switches to Run config for faster movement during crowd avoidance maneuvers.
+do_gamer.crowd_avoidance.other.only_in_preferred_zone=Only in preferred zones
+do_gamer.crowd_avoidance.other.only_in_preferred_zone.desc=When enabled, crowd avoidance is only active while the hero is inside a preferred zone.
 
 orbithelper.fast_travel.use_coupon=Use only the jump coupon
 orbithelper.fast_travel.use_coupon.desc=If enabled, it will only use the jump coupon to jump between maps.

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.3",
+	"version": "0.12.4",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Restrict crowd avoidance behavior to operate only when the hero is inside a user-configurable preferred zone.

New Features:
- Add a configuration option to limit crowd avoidance to preferred zones only.

Enhancements:
- Extend crowd avoidance activation logic to respect the new preferred-zone restriction flag.

Documentation:
- Document the new preferred-zone-only crowd avoidance option in the English localization strings.