### PR TITLE
Simple Galaxy Gate: Updated ABG gate IDs to reverse order (Gamma → Beta → Alpha).

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
@@ -590,7 +590,7 @@ public final class SimpleGalaxyGate implements Module, Task,
 
         // Handle ABG gate ID
         if (gateId == 0) {
-            // Try Alpha, Beta, Gamma in order
+            // Check if any ABG gate is accessible from current map
             for (int id : Maps.ABG_IDS) {
                 if (this.isGateAvailable(id)) {
                     return this.starSystem.getOrCreateMap(id); // Found existing gate

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/Maps.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/Maps.java
@@ -32,7 +32,7 @@ public final class Maps {
         // Prevent instantiation
     }
 
-    public static final List<Integer> ABG_IDS = List.of(51, 52, 53); // Alpha, Beta, Gamma gate IDs
+    public static final List<Integer> ABG_IDS = List.of(53, 52, 51); // Gamma, Beta, Alpha gate IDs
     private static List<MapInfo> ggMaps;
     private static double mapCenterX = Defaults.MAP_CENTER_X;
     private static double mapCenterY = Defaults.MAP_CENTER_Y;
@@ -108,7 +108,7 @@ public final class Maps {
      * Finds mapInfo by gate ID.
      */
     private static MapInfo findMapInfo(int id) {
-        // Map ID 0 represents Alpha/Beta/Gamma group
+        // Map ID 0 is a special case for ABG gates, so we treat it as a wildcard.
         int actualId = ABG_IDS.contains(id) ? 0 : id;
         return ggMaps.stream().filter(mi -> mi.id == actualId).findFirst().orElse(null);
     }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.6",
+	"version": "0.12.7",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Reverse the configured ABG gate ID order and clarify ABG-related comments to better reflect the special handling of these gates.

Enhancements:
- Reverse the ABG gate ID list to prioritize Gamma over Beta and Alpha when resolving gate access.
- Improve documentation comments around ABG gate handling to describe wildcard behavior and accessibility checks more accurately.