### PR TITLE
Simple Galaxy Gate: improved collection and kamikaze logic.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
@@ -78,31 +78,49 @@ public final class CustomCollectorModule extends CollectorModule {
      */
     private void markVisibleBoxesAsFake() {
         for (Box box : new ArrayList<>(this.entities.getBoxes())) {
-            if (box == null
-                    || FakeEntity.isFakeEntity(box)
-                    || !box.isValid()
-                    || box.isCollected()) {
-                continue; // Skip invalid, fake, or collected boxes
+            if (this.shouldSkip(box)) {
+                continue;
             }
 
             String hash = box.getHash();
+            boolean isCargoBox = this.isResource(box.getTypeName());
             FakeEntity.FakeBox fake = this.fakeBoxes.get(hash);
-            long timeout = this.isResource(box.getTypeName()) ? CARGO_BOX_TIMEOUT_MS : FAKE_BOX_TIMEOUT_MS;
 
             if (fake == null || !fake.isValid()) {
-                fake = this.entities.fakeEntityBuilder()
-                        .location(box.getLocationInfo())
-                        .keepAlive(timeout)
-                        .removeOnSelect(true)
-                        .box(box.getInfo());
-                this.fakeBoxes.put(hash, fake);
+                this.fakeBoxes.put(hash, this.createFakeBox(box, isCargoBox));
             } else {
-                fake.setLocation(box.getLocationInfo());
-                fake.setTimeout(timeout);
+                this.updateFakeBox(fake, isCargoBox, box);
             }
         }
 
-        // Clean up invalid or collected fake boxes
+        this.cleanupFakeBoxes();
+    }
+
+    private boolean shouldSkip(Box box) {
+        return box == null
+                || FakeEntity.isFakeEntity(box)
+                || !box.isValid()
+                || box.isCollected();
+    }
+
+    private FakeEntity.FakeBox createFakeBox(Box box, boolean isCargoBox) {
+        return this.entities.fakeEntityBuilder()
+                .location(box.getLocationInfo())
+                .keepAlive(isCargoBox ? CARGO_BOX_TIMEOUT_MS : FAKE_BOX_TIMEOUT_MS)
+                .removeOnSelect(true)
+                .box(box.getInfo());
+    }
+
+    private void updateFakeBox(FakeEntity.FakeBox fake, boolean isCargoBox, Box box) {
+        if (isCargoBox) {
+            return; // Skip updating cargo boxes to avoid resetting their timeout
+        }
+
+        fake.setLocation(box.getLocationInfo());
+        fake.setTimeout(FAKE_BOX_TIMEOUT_MS);
+    }
+
+    private void cleanupFakeBoxes() {
         Iterator<Map.Entry<String, FakeEntity.FakeBox>> iterator = this.fakeBoxes.entrySet().iterator();
         while (iterator.hasNext()) {
             FakeEntity.FakeBox fake = iterator.next().getValue();

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
@@ -17,7 +17,7 @@ import eu.darkbot.shared.modules.CollectorModule;
 
 public final class CustomCollectorModule extends CollectorModule {
 
-    private static final long FAKE_BOX_TIMEOUT_MS = 300_000L;
+    private static final long FAKE_BOX_TIMEOUT_MS = 300_000L; // 5 minutes in milliseconds
 
     private final EntitiesAPI entities;
     private final Map<String, FakeEntity.FakeBox> fakeBoxes = new HashMap<>();
@@ -77,8 +77,12 @@ public final class CustomCollectorModule extends CollectorModule {
      */
     private void markVisibleBoxesAsFake() {
         for (Box box : new ArrayList<>(this.entities.getBoxes())) {
-            if (box == null || FakeEntity.isFakeEntity(box) || !box.isValid() || box.isCollected()) {
-                continue; // Skip invalid or already collected boxes
+            if (box == null
+                    || FakeEntity.isFakeEntity(box)
+                    || !box.isValid()
+                    || box.isCollected()
+                    || this.isResource(box.getTypeName())) {
+                continue; // Skip invalid, fake, collected boxes or cargo boxes
             }
 
             String hash = box.getHash();

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
@@ -18,6 +18,7 @@ import eu.darkbot.shared.modules.CollectorModule;
 public final class CustomCollectorModule extends CollectorModule {
 
     private static final long FAKE_BOX_TIMEOUT_MS = 300_000L; // 5 minutes in milliseconds
+    private static final long CARGO_BOX_TIMEOUT_MS = 30_000L; // 30 seconds in milliseconds
 
     private final EntitiesAPI entities;
     private final Map<String, FakeEntity.FakeBox> fakeBoxes = new HashMap<>();
@@ -80,24 +81,24 @@ public final class CustomCollectorModule extends CollectorModule {
             if (box == null
                     || FakeEntity.isFakeEntity(box)
                     || !box.isValid()
-                    || box.isCollected()
-                    || this.isResource(box.getTypeName())) {
-                continue; // Skip invalid, fake, collected boxes or cargo boxes
+                    || box.isCollected()) {
+                continue; // Skip invalid, fake, or collected boxes
             }
 
             String hash = box.getHash();
             FakeEntity.FakeBox fake = this.fakeBoxes.get(hash);
+            long timeout = this.isResource(box.getTypeName()) ? CARGO_BOX_TIMEOUT_MS : FAKE_BOX_TIMEOUT_MS;
 
             if (fake == null || !fake.isValid()) {
                 fake = this.entities.fakeEntityBuilder()
                         .location(box.getLocationInfo())
-                        .keepAlive(FAKE_BOX_TIMEOUT_MS)
+                        .keepAlive(timeout)
                         .removeOnSelect(true)
                         .box(box.getInfo());
                 this.fakeBoxes.put(hash, fake);
             } else {
                 fake.setLocation(box.getLocationInfo());
-                fake.setTimeout(FAKE_BOX_TIMEOUT_MS);
+                fake.setTimeout(timeout);
             }
         }
 

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
@@ -148,7 +148,11 @@ public final class KamikazeHandler {
      * Checks if the PET HP is low enough for the kamikaze strategy.
      */
     private boolean isPetHpLow() {
-        return this.pet.getHealth().getHp() < PET_LOW_HP;
+        int maxHp = this.pet.getHealth().getMaxHp();
+        int lowHpThreshold = maxHp > 0
+                ? (int) (maxHp * 0.19) // 19% of max HP (required below 20% for kamikaze)
+                : PET_LOW_HP; // Fallback to a fixed low HP threshold if max HP is not available
+        return this.pet.getHealth().getHp() < lowHpThreshold;
     }
 
     /**

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.7",
+	"version": "0.12.8",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Improve box collection filtering and PET kamikaze activation logic based on dynamic health thresholds.

Bug Fixes:
- Prevent cargo/resource boxes from being incorrectly marked as fake during collection.
- Adjust PET kamikaze triggering to use a percentage of max HP, ensuring activation only when health is genuinely low.

Enhancements:
- Clarify fake box timeout constant with an inline duration comment.