### PR TITLE
Simple Galaxy Gate: stop tracking the cargo boxes.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/CustomCollectorModule.java
@@ -18,7 +18,6 @@ import eu.darkbot.shared.modules.CollectorModule;
 public final class CustomCollectorModule extends CollectorModule {
 
     private static final long FAKE_BOX_TIMEOUT_MS = 300_000L; // 5 minutes in milliseconds
-    private static final long CARGO_BOX_TIMEOUT_MS = 30_000L; // 30 seconds in milliseconds
 
     private final EntitiesAPI entities;
     private final Map<String, FakeEntity.FakeBox> fakeBoxes = new HashMap<>();
@@ -83,13 +82,12 @@ public final class CustomCollectorModule extends CollectorModule {
             }
 
             String hash = box.getHash();
-            boolean isCargoBox = this.isResource(box.getTypeName());
             FakeEntity.FakeBox fake = this.fakeBoxes.get(hash);
 
             if (fake == null || !fake.isValid()) {
-                this.fakeBoxes.put(hash, this.createFakeBox(box, isCargoBox));
+                this.fakeBoxes.put(hash, this.createFakeBox(box));
             } else {
-                this.updateFakeBox(fake, isCargoBox, box);
+                this.updateFakeBox(fake, box);
             }
         }
 
@@ -100,22 +98,19 @@ public final class CustomCollectorModule extends CollectorModule {
         return box == null
                 || FakeEntity.isFakeEntity(box)
                 || !box.isValid()
-                || box.isCollected();
+                || box.isCollected()
+                || this.isResource(box.getTypeName()); // Skip cargo boxes (they despawn in 30 seconds)
     }
 
-    private FakeEntity.FakeBox createFakeBox(Box box, boolean isCargoBox) {
+    private FakeEntity.FakeBox createFakeBox(Box box) {
         return this.entities.fakeEntityBuilder()
                 .location(box.getLocationInfo())
-                .keepAlive(isCargoBox ? CARGO_BOX_TIMEOUT_MS : FAKE_BOX_TIMEOUT_MS)
+                .keepAlive(FAKE_BOX_TIMEOUT_MS)
                 .removeOnSelect(true)
                 .box(box.getInfo());
     }
 
-    private void updateFakeBox(FakeEntity.FakeBox fake, boolean isCargoBox, Box box) {
-        if (isCargoBox) {
-            return; // Skip updating cargo boxes to avoid resetting their timeout
-        }
-
+    private void updateFakeBox(FakeEntity.FakeBox fake, Box box) {
         fake.setLocation(box.getLocationInfo());
         fake.setTimeout(FAKE_BOX_TIMEOUT_MS);
     }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.8",
+	"version": "0.12.9",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Stop tracking cargo/resource cargo boxes in the Simple Galaxy Gate collector by only creating and updating long-lived fake entities for non-cargo boxes.

Bug Fixes:
- Prevent fake tracking of short-lived cargo boxes that despawn quickly, reducing unnecessary entity management and potential inconsistencies.

Enhancements:
- Simplify fake box lifetime handling by using a single timeout for all tracked boxes and removing cargo-specific timeout logic.