### PR TITLE
Retarget Kamikaze corner movement

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
@@ -318,14 +318,33 @@ public final class KamikazeHandler {
      * Handles movement in corner mode
      */
     private void handleCornerMovement() {
-        if (this.lootModule.getAttacker().hasTarget()) {
-            this.movement.moveTo(this.lootModule.getAttacker().getTarget());
+        List<Npc> validTargets = this.getValidTargets(true);
+        Npc currentTarget = this.lootModule.getAttacker().getTargetAs(Npc.class);
+        Npc closestTarget = this.getClosestTarget(validTargets);
+
+        if (closestTarget != null && this.shouldSwitchCornerTarget(currentTarget, closestTarget)) {
+            this.lockTarget(closestTarget);
+            currentTarget = closestTarget;
+        }
+
+        if (currentTarget != null) {
+            this.movement.moveTo(currentTarget);
             return;
         }
-        List<Npc> validTargets = this.getValidTargets(true);
-        if (!validTargets.isEmpty()) {
-            this.lockClosestTarget(validTargets);
+
+        if (closestTarget != null) {
+            this.lockTarget(closestTarget);
         }
+    }
+
+    /**
+     * Determines if corner mode should switch away from the current target.
+     */
+    private boolean shouldSwitchCornerTarget(Npc currentTarget, Npc closestTarget) {
+        if (currentTarget == null || !currentTarget.isValid() || !this.isValidTarget(currentTarget, true)) {
+            return true;
+        }
+        return closestTarget.distanceTo(this.hero) < currentTarget.distanceTo(this.hero);
     }
 
     /**
@@ -359,14 +378,28 @@ public final class KamikazeHandler {
      * Lock the closest NPC to the hero
      */
     private void lockClosestTarget(List<Npc> validTargets) {
-        Npc closest = validTargets.stream()
-                .min(Comparator.comparingDouble(n -> n.distanceTo(this.hero)))
-                .orElse(null);
+        Npc closest = this.getClosestTarget(validTargets);
 
         if (closest != null) {
-            this.lootModule.getAttacker().setTarget(closest);
-            this.lootModule.getAttacker().tryLockTarget();
+            this.lockTarget(closest);
         }
+    }
+
+    /**
+     * Returns the closest valid target to the hero.
+     */
+    private Npc getClosestTarget(List<Npc> validTargets) {
+        return validTargets.stream()
+                .min(Comparator.comparingDouble(n -> n.distanceTo(this.hero)))
+                .orElse(null);
+    }
+
+    /**
+     * Locks the given target.
+     */
+    private void lockTarget(Npc target) {
+        this.lootModule.getAttacker().setTarget(target);
+        this.lootModule.getAttacker().tryLockTarget();
     }
 
     /**

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/KamikazeHandler.java
@@ -327,13 +327,10 @@ public final class KamikazeHandler {
             currentTarget = closestTarget;
         }
 
-        if (currentTarget != null) {
+        if (currentTarget != null
+                && currentTarget.isValid()
+                && this.isValidTarget(currentTarget, true)) {
             this.movement.moveTo(currentTarget);
-            return;
-        }
-
-        if (closestTarget != null) {
-            this.lockTarget(closestTarget);
         }
     }
 

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.10",
+	"version": "0.12.11",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary
Fixes #181 by re-evaluating the active corner-mode Kamikaze target instead of always chasing the previously locked target.

## Changes
- Re-checks valid Kamikaze targets during corner movement.
- Switches to the closest valid target when the current target is invalid, no longer valid for corner mode, or farther than another valid target.
- Extracts small helpers for closest-target selection and locking.

## Testing
- `gradle build --no-daemon` using Gradle 9.6.1 and Temurin JDK 25
- Build successful

## Notes
I did not change the normal Kamikaze grouping behavior outside corner mode.

## Summary by Sourcery

Update Kamikaze corner-mode movement to dynamically retarget enemies based on current validity and proximity instead of persisting a stale lock.

Bug Fixes:
- Ensure Kamikaze corner-mode no longer chases invalid or suboptimal targets by re-evaluating and switching to the closest valid NPC.

Enhancements:
- Extract helpers for closest-target selection, target locking, and corner-mode retargeting decisions to simplify Kamikaze handling logic.