### PR TITLE
Simple Galaxy Gate: added Gauntlet Of Plutus gate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ We will seek to implement CI/CD in the repository so that developers have a good
 - GG Alert Closer: Closes alerts at Galaxy Gates (Hades, LoW and Kuiper). By @do-gamer & @orbithelper
 - Fast Travel: Fast travel between maps using Jump CPU (AJP-01). By @do-gamer & @orbithelper
 - Orbit Helper Quick Login: Adds a button to navigate to Orbit Helper from the menu. By @orbithelper
-- Simple Galaxy Gate: Supports ABG, Delta, Epsilon, Zeta, Hades, Kuiper, LoW, Invasion, Treacherous, Trinity, DSE, Mimesis and EBG. By @do-gamer
+- Simple Galaxy Gate: Supports ABG, Delta, Epsilon, Zeta, Hades, Kuiper, LoW, Invasion, Treacherous, Trinity, DSE, Mimesis, EBG and GoP. By @do-gamer
 - Autobuy: Automatically buys boosters and special items from the shop at a configured interval. By @do-gamer
 - Log Overlay: Displays the latest in-game log messages on the canvas (top-center, auto-fade after 5s). Built-in keyword whitelist limits the displayed lines to gains and errors so the canvas does not get cluttered. By @Halizeur
 

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/SimpleGalaxyGate.java
@@ -40,7 +40,7 @@ import eu.darkbot.shared.utils.MapTraveler;
 import eu.darkbot.shared.utils.PortalJumper;
 import eu.darkbot.util.Timer;
 
-@Feature(name = "Simple Galaxy Gate", description = "Supports ABG, Delta, Epsilon, Zeta, Hades, Kuiper, LoW, Invasion, Treacherous, Trinity, DSE, Mimesis and EBG.")
+@Feature(name = "Simple Galaxy Gate", description = "Supports ABG, Delta, Epsilon, Zeta, Hades, Kuiper, LoW, Invasion, Treacherous, Trinity, DSE, Mimesis, EBG and GoP.")
 public final class SimpleGalaxyGate implements Module, Task,
         Configurable<SimpleGalaxyGateConfig>,
         NpcExtraProvider {

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/Maps.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/config/Maps.java
@@ -16,6 +16,7 @@ import dev.shared.do_gamer.module.simple_galaxy_gate.gate.DseGate;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.EpsilonGate;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.EternalBlacklightGate;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.GateHandler;
+import dev.shared.do_gamer.module.simple_galaxy_gate.gate.GopGate;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.HadesGate;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.InvasionGate;
 import dev.shared.do_gamer.module.simple_galaxy_gate.gate.KuiperGate;
@@ -100,6 +101,8 @@ public final class Maps {
         list.add(new MapInfo(-3, "Mimesis Mutiny", null, StarSystemAPI.BASE_MAPS, MimesisMutinyGate::new));
         list.add(new MapInfo(-4, "Eternal Blacklight", null, StarSystemAPI.BLACK_LIGHT_MAPS,
                 EternalBlacklightGate::new));
+        list.add(new MapInfo(410, "Gauntlet Of Plutus (Normal)", null, StarSystemAPI.OUTPOST_HOME_MAPS, GopGate::new));
+        list.add(new MapInfo(450, "Gauntlet Of Plutus (Easy)", null, StarSystemAPI.HOME_MAPS, GopGate::new));
 
         ggMaps = Collections.unmodifiableList(list);
     }

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -1,0 +1,149 @@
+package dev.shared.do_gamer.module.simple_galaxy_gate.gate;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import dev.shared.do_gamer.module.simple_galaxy_gate.StateStore;
+import eu.darkbot.api.PluginAPI;
+import eu.darkbot.api.game.entities.Npc;
+import eu.darkbot.api.game.entities.StaticEntity.PlutusGenerator;
+import eu.darkbot.api.managers.GauntletPlutusAPI;
+
+public final class GopGate extends GateHandler {
+    private static final String SEEKER_ROCKET_NAME = "-=[ Seeker Rocket ]=-";
+    private static final String WARHEAD_NAME = "-=[ Warhead ]=-";
+    private static final String PLUTUS_NAME = "=^(Plutus)^=";
+    private static final String TURRET_NAME = "-=[ Turret ]=-";
+
+    private GauntletPlutusAPI gopApi;
+
+    public GopGate() {
+        this.npcMap.put(SEEKER_ROCKET_NAME, new NpcParam(600.0, -80));
+        this.npcMap.put(WARHEAD_NAME, new NpcParam(600.0, -80));
+        this.npcMap.put(PLUTUS_NAME, new NpcParam(600.0, -20));
+        this.defaultNpcParam = new NpcParam(580.0);
+        this.moveToCenter = false;
+        this.showCompletedGates = false;
+    }
+
+    @Override
+    protected void onModuleSet(PluginAPI api) {
+        this.gopApi = api.requireAPI(GauntletPlutusAPI.class);
+    }
+
+    @Override
+    public boolean prepareTickModule() {
+        if (this.gopApi == null) {
+            return false;
+        }
+
+        GauntletPlutusAPI.Status status = this.gopApi.getStatus();
+        if (status != GauntletPlutusAPI.Status.AVAILABLE) {
+            if (this.module.moveToRefinery()) {
+                StateStore.request(StateStore.State.MOVE_TO_SAFE_POSITION);
+            } else {
+                this.statusDetails = status == GauntletPlutusAPI.Status.COMPLETED
+                        ? "gate is completed."
+                        : "gate not available.";
+                StateStore.request(StateStore.State.WAITING);
+            }
+            return true;
+        }
+        this.reset();
+        return false;
+    }
+
+    @Override
+    public void reset() {
+        this.statusDetails = null;
+    }
+
+    private boolean isPlutus(Npc npc) {
+        return this.nameContains(npc, PLUTUS_NAME);
+    }
+
+    private boolean isPlutusPresent() {
+        return this.module.lootModule.getNpcs().stream().anyMatch(this::isPlutus);
+    }
+
+    private boolean isRocket(Npc npc) {
+        return this.nameContains(npc, SEEKER_ROCKET_NAME) || this.nameContains(npc, WARHEAD_NAME);
+    }
+
+    private boolean isRocketPresent() {
+        return this.module.lootModule.getNpcs().stream().anyMatch(this::isRocket);
+    }
+
+    private boolean isTurret(Npc npc) {
+        return this.nameContains(npc, TURRET_NAME);
+    }
+
+    /**
+     * Gets the nearest Turret NPC to the hero.
+     */
+    private Npc getTurretNpc() {
+        return this.module.lootModule.getNpcs().stream()
+                .filter(this::isTurret)
+                .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
+                .orElse(null);
+    }
+
+    /**
+     * Handles the attack on the turret if it is present and no rockets are present.
+     */
+    private boolean handleTurretAttack() {
+        if (this.isRocketPresent()) {
+            return false;
+        }
+
+        Npc npc = this.getTurretNpc();
+        if (npc != null) {
+            this.module.lootModule.moveToTarget(npc);
+            this.module.lootModule.getAttacker().tryLockAndAttack();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean attackTickModule() {
+        if (!this.isPlutusPresent()) {
+            return false;
+        }
+
+        if (this.handleTurretAttack()) {
+            return true;
+        }
+
+        return this.moveToHealGenerator();
+    }
+
+    /**
+     * Moves the hero to the nearest heal generator if one is present.
+     */
+    private boolean moveToHealGenerator() {
+        PlutusGenerator healGenerator = this.getGenerators().stream()
+                .filter(PlutusGenerator::isHealType)
+                .min(Comparator.comparingDouble(g -> g.distanceTo(this.module.hero)))
+                .orElse(null);
+
+        if (healGenerator != null) {
+            this.module.movement.moveTo(healGenerator);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Gets a list of all generators in the map.
+     */
+    private List<PlutusGenerator> getGenerators() {
+        return this.module.entities.getStaticEntities().stream()
+                .filter(Objects::nonNull)
+                .filter(PlutusGenerator.class::isInstance)
+                .map(PlutusGenerator.class::cast)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -116,11 +116,7 @@ public final class GopGate extends GateHandler {
             return false;
         }
 
-        if (this.moveToHealGenerator() || this.handleRocketOrTurretAttack()) {
-            return true;
-        }
-
-        return false;
+        return this.moveToHealGenerator() || this.handleRocketOrTurretAttack();
     }
 
     /**

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -1,7 +1,6 @@
 package dev.shared.do_gamer.module.simple_galaxy_gate.gate;
 
 import java.util.Comparator;
-import java.util.Objects;
 
 import dev.shared.do_gamer.module.simple_galaxy_gate.StateStore;
 import eu.darkbot.api.PluginAPI;
@@ -123,7 +122,6 @@ public final class GopGate extends GateHandler {
      */
     private boolean moveToHealGenerator() {
         PlutusGenerator healGenerator = this.module.entities.getStaticEntities().stream()
-                .filter(Objects::nonNull)
                 .filter(PlutusGenerator.class::isInstance)
                 .map(PlutusGenerator.class::cast)
                 .filter(PlutusGenerator::isHealType)

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -69,8 +69,14 @@ public final class GopGate extends GateHandler {
         return this.nameContains(npc, SEEKER_ROCKET_NAME) || this.nameContains(npc, WARHEAD_NAME);
     }
 
-    private boolean isRocketPresent() {
-        return this.module.lootModule.getNpcs().stream().anyMatch(this::isRocket);
+    /**
+     * Gets the nearest Rocket NPC to the hero.
+     */
+    private Npc getRocketNpc() {
+        return this.module.lootModule.getNpcs().stream()
+                .filter(this::isRocket)
+                .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
+                .orElse(null);
     }
 
     private boolean isTurret(Npc npc) {
@@ -88,14 +94,14 @@ public final class GopGate extends GateHandler {
     }
 
     /**
-     * Handles the attack on the turret if it is present and no rockets are present.
+     * Handles attacking the nearest rocket or turret NPC if one is present.
      */
-    private boolean handleTurretAttack() {
-        if (this.isRocketPresent()) {
-            return false;
+    private boolean handleRocketOrTurretAttack() {
+        // Attack the rocket first
+        Npc npc = this.getRocketNpc();
+        if (npc == null) {
+            npc = this.getTurretNpc();
         }
-
-        Npc npc = this.getTurretNpc();
         if (npc != null) {
             this.module.lootModule.moveToTarget(npc);
             this.module.lootModule.getAttacker().tryLockAndAttack();
@@ -110,11 +116,11 @@ public final class GopGate extends GateHandler {
             return false;
         }
 
-        if (this.handleTurretAttack()) {
+        if (this.moveToHealGenerator() || this.handleRocketOrTurretAttack()) {
             return true;
         }
 
-        return this.moveToHealGenerator();
+        return false;
     }
 
     /**

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -1,9 +1,7 @@
 package dev.shared.do_gamer.module.simple_galaxy_gate.gate;
 
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import dev.shared.do_gamer.module.simple_galaxy_gate.StateStore;
 import eu.darkbot.api.PluginAPI;
@@ -124,7 +122,10 @@ public final class GopGate extends GateHandler {
      * Moves the hero to the nearest heal generator if one is present.
      */
     private boolean moveToHealGenerator() {
-        PlutusGenerator healGenerator = this.getGenerators().stream()
+        PlutusGenerator healGenerator = this.module.entities.getStaticEntities().stream()
+                .filter(Objects::nonNull)
+                .filter(PlutusGenerator.class::isInstance)
+                .map(PlutusGenerator.class::cast)
                 .filter(PlutusGenerator::isHealType)
                 .min(Comparator.comparingDouble(g -> g.distanceTo(this.module.hero)))
                 .orElse(null);
@@ -134,16 +135,5 @@ public final class GopGate extends GateHandler {
             return true;
         }
         return false;
-    }
-
-    /**
-     * Gets a list of all generators in the map.
-     */
-    private List<PlutusGenerator> getGenerators() {
-        return this.module.entities.getStaticEntities().stream()
-                .filter(Objects::nonNull)
-                .filter(PlutusGenerator.class::isInstance)
-                .map(PlutusGenerator.class::cast)
-                .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.11",
+	"version": "0.12.12",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Add support for the Gauntlet Of Plutus (GoP) galaxy gate to the Simple Galaxy Gate module.

New Features:
- Introduce Gauntlet Of Plutus gate handler with custom NPC and generator logic for gate behavior.
- Register Gauntlet Of Plutus maps (normal and easy variants) in the galaxy gate configuration.

Documentation:
- Update README and feature description to document GoP support in Simple Galaxy Gate.