### PR TITLE
Simple Galaxy Gate: increased NPC radius for GoP, Trinity Trials, and Voyagers Ascent gate.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -33,10 +33,10 @@ public final class GopGate extends GateHandler {
     private Npc rocketNpcCache;
 
     public GopGate() {
-        this.npcMap.put(SEEKER_ROCKET_NAME, new NpcParam(600.0, -80));
-        this.npcMap.put(WARHEAD_NAME, new NpcParam(600.0, -80));
-        this.npcMap.put(PLUTUS_NAME, new NpcParam(600.0));
-        this.defaultNpcParam = new NpcParam(580.0);
+        this.npcMap.put(SEEKER_ROCKET_NAME, new NpcParam(620.0, -80));
+        this.npcMap.put(WARHEAD_NAME, new NpcParam(620.0, -80));
+        this.npcMap.put(PLUTUS_NAME, new NpcParam(620.0));
+        this.defaultNpcParam = new NpcParam(600.0);
         this.showCompletedGates = false;
         this.approachToCenter = false;
         this.skipFarTargets = false;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/TrinityTrialsGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/TrinityTrialsGate.java
@@ -21,7 +21,7 @@ public final class TrinityTrialsGate extends DifficultySelectGateHandler {
         super(DIFFICULTY_SELECT_GUI, PORTAL_TYPE_ID, GO_BUTTON_X, GO_BUTTON_Y);
         this.npcMap.put("..::{ Pyrospire }::..", new NpcParam(620.0));
         this.npcMap.put("..::{ Vinespire }::..", new NpcParam(620.0));
-        this.defaultNpcParam = new NpcParam(580.0);
+        this.defaultNpcParam = new NpcParam(600.0);
         this.jumpToNextMap = false;
         this.safeRefreshInGate = false;
         this.fetchServerOffset = true;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/VoyagersAscentGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/VoyagersAscentGate.java
@@ -10,7 +10,7 @@ public final class VoyagersAscentGate extends DifficultySelectGateHandler {
 
     public VoyagersAscentGate() {
         super(DIFFICULTY_SELECT_GUI, PORTAL_TYPE_ID, GO_BUTTON_X, GO_BUTTON_Y);
-        this.defaultNpcParam = new NpcParam(580.0);
+        this.defaultNpcParam = new NpcParam(600.0);
         this.jumpToNextMap = false;
         this.safeRefreshInGate = false;
     }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.15",
+	"version": "0.12.16",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Increase NPC targeting radius defaults for specific Simple Galaxy Gate configurations to improve behavior in GoP, Trinity Trials, and Voyagers Ascent gates.

Enhancements:
- Adjust NPC-specific and default radius parameters in GopGate to use slightly larger values.
- Increase default NPC radius parameters for TrinityTrialsGate and VoyagersAscentGate.