### PR TITLE
Simple Galaxy Gate (GoP): kill nearest NPC while moving to heal generator. Also adjusted default radiuses.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -203,6 +203,16 @@ public final class GopGate extends GateHandler {
     }
 
     /**
+     * Gets the nearest selectable, non-Plutus NPC to the hero.
+     */
+    private Npc getNearestNpcExcludingPlutus() {
+        return this.module.lootModule.getNpcs().stream()
+                .filter(n -> n != null && n.isValid() && n.isSelectable() && !this.isPlutus(n))
+                .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
+                .orElse(null);
+    }
+
+    /**
      * Moves the hero to the nearest heal generator if one is present.
      */
     private boolean moveToHealGenerator() {
@@ -217,10 +227,7 @@ public final class GopGate extends GateHandler {
             this.module.movement.moveTo(healGenerator);
 
             // Kill the nearest NPC if one is present while moving to the heal generator
-            Npc nearestNpc = this.module.lootModule.getNpcs().stream()
-                    .filter(n -> n != null && n.isValid() && n.isSelectable() && !this.isPlutus(n))
-                    .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
-                    .orElse(null);
+            Npc nearestNpc = this.getNearestNpcExcludingPlutus();
             if (nearestNpc != null) {
                 this.module.lootModule.getAttacker().setTarget(nearestNpc);
                 this.module.lootModule.getAttacker().tryLockAndAttack();

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -33,10 +33,14 @@ public final class GopGate extends GateHandler {
     private Npc rocketNpcCache;
 
     public GopGate() {
-        this.npcMap.put(SEEKER_ROCKET_NAME, new NpcParam(620.0, -80));
-        this.npcMap.put(WARHEAD_NAME, new NpcParam(620.0, -80));
-        this.npcMap.put(PLUTUS_NAME, new NpcParam(620.0));
-        this.defaultNpcParam = new NpcParam(590.0);
+        this.npcMap.put(SEEKER_ROCKET_NAME, new NpcParam(600.0, -80));
+        this.npcMap.put(WARHEAD_NAME, new NpcParam(600.0, -80));
+        this.npcMap.put(PLUTUS_NAME, new NpcParam(580.0));
+        this.npcMap.put("-=[ Kristallon ]=-", new NpcParam(580.0));
+        this.npcMap.put("( UberLordakium )", new NpcParam(590.0));
+        this.npcMap.put("=^(Natal Nap)^=", new NpcParam(520.0));
+        this.npcMap.put("=^(Kodkod)^=", new NpcParam(580.0));
+        this.defaultNpcParam = new NpcParam(560.0);
         this.showCompletedGates = false;
         this.approachToCenter = false;
         this.skipFarTargets = false;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -216,10 +216,13 @@ public final class GopGate extends GateHandler {
         if (healGenerator != null) {
             this.module.movement.moveTo(healGenerator);
 
-            // Kill the nearest rocket if one is present while moving to the heal generator
-            Npc rocketNpc = this.getRocketNpc();
-            if (rocketNpc != null) {
-                this.module.lootModule.getAttacker().setTarget(rocketNpc);
+            // Kill the nearest NPC if one is present while moving to the heal generator
+            Npc nearestNpc = this.module.lootModule.getNpcs().stream()
+                    .filter(n -> n != null && n.isValid() && n.isSelectable() && !this.isPlutus(n))
+                    .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
+                    .orElse(null);
+            if (nearestNpc != null) {
+                this.module.lootModule.getAttacker().setTarget(nearestNpc);
                 this.module.lootModule.getAttacker().tryLockAndAttack();
             }
             return true;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -36,7 +36,7 @@ public final class GopGate extends GateHandler {
         this.npcMap.put(SEEKER_ROCKET_NAME, new NpcParam(620.0, -80));
         this.npcMap.put(WARHEAD_NAME, new NpcParam(620.0, -80));
         this.npcMap.put(PLUTUS_NAME, new NpcParam(620.0));
-        this.defaultNpcParam = new NpcParam(600.0);
+        this.defaultNpcParam = new NpcParam(590.0);
         this.showCompletedGates = false;
         this.approachToCenter = false;
         this.skipFarTargets = false;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -207,7 +207,8 @@ public final class GopGate extends GateHandler {
      */
     private Npc getNearestNpcExcludingPlutus() {
         return this.module.lootModule.getNpcs().stream()
-                .filter(n -> n != null && n.isValid() && n.isSelectable() && !this.isPlutus(n))
+                .filter(n -> n != null && n.isValid() && n.isSelectable()
+                        && !this.isPlutus(n) && n.distanceTo(this.module.hero) <= 800.0)
                 .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
                 .orElse(null);
     }

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/TrinityTrialsGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/TrinityTrialsGate.java
@@ -21,7 +21,7 @@ public final class TrinityTrialsGate extends DifficultySelectGateHandler {
         super(DIFFICULTY_SELECT_GUI, PORTAL_TYPE_ID, GO_BUTTON_X, GO_BUTTON_Y);
         this.npcMap.put("..::{ Pyrospire }::..", new NpcParam(620.0));
         this.npcMap.put("..::{ Vinespire }::..", new NpcParam(620.0));
-        this.defaultNpcParam = new NpcParam(600.0);
+        this.defaultNpcParam = new NpcParam(580.0);
         this.jumpToNextMap = false;
         this.safeRefreshInGate = false;
         this.fetchServerOffset = true;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/VoyagersAscentGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/VoyagersAscentGate.java
@@ -10,7 +10,7 @@ public final class VoyagersAscentGate extends DifficultySelectGateHandler {
 
     public VoyagersAscentGate() {
         super(DIFFICULTY_SELECT_GUI, PORTAL_TYPE_ID, GO_BUTTON_X, GO_BUTTON_Y);
-        this.defaultNpcParam = new NpcParam(600.0);
+        this.defaultNpcParam = new NpcParam(580.0);
         this.jumpToNextMap = false;
         this.safeRefreshInGate = false;
     }

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.16",
+	"version": "0.12.17",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Adjust Simple Galaxy Gate behaviour to target the nearest non-Plutus NPC while moving to heal generators, and retune NPC distance parameters across several gates.

New Features:
- Add logic to select and attack the nearest valid, selectable non-Plutus NPC within range while moving toward a heal generator.
- Extend NPC configuration in Simple Galaxy Gate to include additional NPC types with specific distance parameters.

Enhancements:
- Retune default and per-NPC distance parameters for Simple Galaxy, Trinity Trials, and Voyagers Ascent gates to adjust engagement ranges.