### PR TITLE
Simple Galaxy Gate (GoP): Refactor rocket/turret attack logic.

### DIFF
--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -26,12 +26,6 @@ public final class GopGate extends GateHandler {
     private boolean plutusPresentCache;
     private boolean turretPresentCache;
 
-    // Per-tick cache for the nearest Rocket NPC, to avoid repeating the
-    // stream/filter/min lookup when getRocketNpc() is called more than once
-    // within the same tick.
-    private boolean rocketNpcCacheDirty = true;
-    private Npc rocketNpcCache;
-
     public GopGate() {
         this.npcMap.put(SEEKER_ROCKET_NAME, new NpcParam(600.0, -80));
         this.npcMap.put(WARHEAD_NAME, new NpcParam(600.0, -80));
@@ -77,7 +71,6 @@ public final class GopGate extends GateHandler {
     public void reset() {
         this.statusDetails = null;
         this.presenceCacheDirty = true;
-        this.rocketNpcCacheDirty = true;
     }
 
     /**
@@ -129,21 +122,16 @@ public final class GopGate extends GateHandler {
     }
 
     /**
-     * Gets the nearest Rocket NPC to the hero.
-     * The result is cached per tick, invalidated at the start of each tick.
+     * Gets the nearest Rocket NPC to the hero for the given priority.
      */
     private Npc getRocketNpc(int priority) {
-        if (this.rocketNpcCacheDirty) {
-            this.rocketNpcCache = this.module.lootModule.getNpcs().stream()
-                    .filter(n -> this.isRocket(n)
-                            && n.getInfo().getPriority() <= priority // Ignore NPCs with lower priority than the turret
-                            && n.getInfo().hasExtraFlag(NpcFlag.PASSIVE) // Ignore passive NPCs
-                    )
-                    .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
-                    .orElse(null);
-            this.rocketNpcCacheDirty = false;
-        }
-        return this.rocketNpcCache;
+        return this.module.lootModule.getNpcs().stream()
+                .filter(n -> this.isRocket(n)
+                        && n.getInfo().getPriority() <= priority // Ignore NPCs with lower priority than the turret
+                        && n.getInfo().hasExtraFlag(NpcFlag.PASSIVE) // Ignore passive NPCs
+                )
+                .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
+                .orElse(null);
     }
 
     /**
@@ -198,10 +186,10 @@ public final class GopGate extends GateHandler {
 
     @Override
     public boolean attackTickModule() {
-        // Invalidate the per-tick caches at the start of each tick, since it's
-        // called before shouldKillNpc/getTargetRadius are evaluated per NPC.
+        // Invalidate the per-tick presence cache at the start of each tick,
+        // since it's called before shouldKillNpc/getTargetRadius are
+        // evaluated per NPC.
         this.presenceCacheDirty = true;
-        this.rocketNpcCacheDirty = true;
 
         if (!this.isPlutusPresent()) {
             return false;

--- a/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
+++ b/src/main/java/dev/shared/do_gamer/module/simple_galaxy_gate/gate/GopGate.java
@@ -132,10 +132,13 @@ public final class GopGate extends GateHandler {
      * Gets the nearest Rocket NPC to the hero.
      * The result is cached per tick, invalidated at the start of each tick.
      */
-    private Npc getRocketNpc() {
+    private Npc getRocketNpc(int priority) {
         if (this.rocketNpcCacheDirty) {
             this.rocketNpcCache = this.module.lootModule.getNpcs().stream()
-                    .filter(this::isRocket)
+                    .filter(n -> this.isRocket(n)
+                            && n.getInfo().getPriority() <= priority // Ignore NPCs with lower priority than the turret
+                            && n.getInfo().hasExtraFlag(NpcFlag.PASSIVE) // Ignore passive NPCs
+                    )
                     .min(Comparator.comparingDouble(npc -> npc.distanceTo(this.module.hero)))
                     .orElse(null);
             this.rocketNpcCacheDirty = false;
@@ -178,8 +181,9 @@ public final class GopGate extends GateHandler {
         return this.module.lootModule.getNpcs().stream()
                 .anyMatch(n -> n != null && n.isValid() && n.isSelectable()
                         && !this.isTurret(n) && !this.isPlutus(n) // Ignore Turrets and Plutus
+                        && !this.isRocket(n) // Ignore Rockets
                         && !n.getInfo().hasExtraFlag(NpcFlag.PASSIVE) // Ignore passive NPCs
-                        && n.getInfo().getPriority() <= priority // Ignore NPCs with higest priority
+                        && n.getInfo().getPriority() <= priority // Ignore NPCs with lower priority
                 );
     }
 
@@ -246,19 +250,37 @@ public final class GopGate extends GateHandler {
      * Handles attacking the nearest rocket or turret NPC if one is present.
      */
     private boolean handleRocketOrTurretAttack() {
-        Npc npc = this.getTurretNpc();
-        if (npc != null) {
-            Npc rocketNpc = this.getRocketNpc();
-            if (rocketNpc != null) {
-                npc = rocketNpc; // Prioritize attacking rockets over turrets
-            } else if (this.hasOtherNpc(npc.getInfo().getPriority())) {
-                return false; // If there are other NPCs, don't attack the turret
-            }
-            this.module.lootModule.moveToTarget(npc);
-            this.module.lootModule.getAttacker().tryLockAndAttack();
-            return true;
+        Npc turretNpc = this.getTurretNpc();
+        if (turretNpc == null) {
+            return false;
         }
-        return false;
+
+        Npc targetNpc = this.selectRocketOrTurretTarget(turretNpc);
+        if (targetNpc == null) {
+            return false;
+        }
+
+        this.module.lootModule.moveToTarget(targetNpc);
+        this.module.lootModule.getAttacker().tryLockAndAttack();
+        return true;
+    }
+
+    /**
+     * Chooses the NPC to attack between the given turret and any rocket
+     * threatening it, prioritizing rockets. Returns {@code null} if the
+     * turret shouldn't be attacked yet because other higher-priority NPCs
+     * are still present.
+     */
+    private Npc selectRocketOrTurretTarget(Npc turretNpc) {
+        int turretPriority = turretNpc.getInfo().getPriority();
+        Npc rocketNpc = this.getRocketNpc(turretPriority);
+        if (rocketNpc != null) {
+            return rocketNpc; // Prioritize attacking rockets over turrets
+        }
+        if (this.hasOtherNpc(turretPriority)) {
+            return null; // If there are other NPCs, don't attack the turret
+        }
+        return turretNpc;
     }
 
     @Override

--- a/src/main/resources/plugin.json
+++ b/src/main/resources/plugin.json
@@ -1,7 +1,7 @@
 {
 	"name": "SharedPlugin",
 	"author": "Several Devs",
-	"version": "0.12.17",
+	"version": "0.12.18",
 	"minVersion": "1.131.6 beta 3",
 	"supportedVersion": "1.132.0 alpha 2",
 	"basePackage": "dev.shared",


### PR DESCRIPTION
## Summary by Sourcery

Refine rocket and turret attack selection logic in the Simple Galaxy Gate module to prioritize rockets correctly and avoid unnecessary turret attacks.

Bug Fixes:
- Ensure rockets are only considered as targets when they are non-passive and have appropriate priority relative to the turret.
- Prevent turrets from being attacked while other higher-priority non-rocket NPCs are still present.

Enhancements:
- Remove the per-tick rocket NPC cache in favor of priority-aware on-demand selection logic.
- Introduce a dedicated helper to choose between attacking a turret or a threatening rocket, simplifying the attack flow.